### PR TITLE
Add layered projects for domain, application, and infrastructure

### DIFF
--- a/ProyectoBase.Api/Program.cs
+++ b/ProyectoBase.Api/Program.cs
@@ -1,3 +1,5 @@
+using ProyectoBase.Domain;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -37,8 +39,3 @@ app.MapGet("/weatherforecast", () =>
 .WithOpenApi();
 
 app.Run();
-
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
-{
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-}

--- a/ProyectoBase.Api/ProyectoBase.Api.csproj
+++ b/ProyectoBase.Api/ProyectoBase.Api.csproj
@@ -16,4 +16,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\ProyectoBase.Application\ProyectoBase.Application.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/ProyectoBase.Application/Class1.cs
+++ b/ProyectoBase.Application/Class1.cs
@@ -1,0 +1,5 @@
+namespace ProyectoBase.Application;
+
+public class Class1
+{
+}

--- a/ProyectoBase.Application/ProyectoBase.Application.csproj
+++ b/ProyectoBase.Application/ProyectoBase.Application.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ProyectoBase.Domain\ProyectoBase.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/ProyectoBase.Domain/ProyectoBase.Domain.csproj
+++ b/ProyectoBase.Domain/ProyectoBase.Domain.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/ProyectoBase.Domain/WeatherForecast.cs
+++ b/ProyectoBase.Domain/WeatherForecast.cs
@@ -1,0 +1,6 @@
+namespace ProyectoBase.Domain;
+
+public record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/ProyectoBase.Infrastructure/Class1.cs
+++ b/ProyectoBase.Infrastructure/Class1.cs
@@ -1,0 +1,5 @@
+namespace ProyectoBase.Infrastructure;
+
+public class Class1
+{
+}

--- a/ProyectoBase.Infrastructure/ProyectoBase.Infrastructure.csproj
+++ b/ProyectoBase.Infrastructure/ProyectoBase.Infrastructure.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ProyectoBase.Application\ProyectoBase.Application.csproj" />
+    <ProjectReference Include="..\ProyectoBase.Domain\ProyectoBase.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/ProyectoBase.sln
+++ b/ProyectoBase.sln
@@ -1,34 +1,75 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Api", "ProyectoBase.Api\ProyectoBase.Api.csproj", "{B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Domain", "ProyectoBase.Domain\ProyectoBase.Domain.csproj", "{C65F0F41-E0CB-4919-8348-DB3AA8A4949F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Application", "ProyectoBase.Application\ProyectoBase.Application.csproj", "{1D73C601-A31A-4F59-A51B-D26E80292F7F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Infrastructure", "ProyectoBase.Infrastructure\ProyectoBase.Infrastructure.csproj", "{21250535-58FB-4EBE-8A40-202D033FCEAD}"
+EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
-		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
-		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Debug|x64.Build.0 = Debug|Any CPU
-		{B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Debug|x86.Build.0 = Debug|Any CPU
-		{B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Release|x64.ActiveCfg = Release|Any CPU
-		{B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Release|x64.Build.0 = Release|Any CPU
-		{B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Release|x86.ActiveCfg = Release|Any CPU
-		{B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                Debug|Any CPU = Debug|Any CPU
+                Debug|x64 = Debug|x64
+                Debug|x86 = Debug|x86
+                Release|Any CPU = Release|Any CPU
+                Release|x64 = Release|x64
+                Release|x86 = Release|x86
+        EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Debug|x64.Build.0 = Debug|Any CPU
+                {B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Debug|x86.Build.0 = Debug|Any CPU
+                {B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Release|Any CPU.Build.0 = Release|Any CPU
+                {B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Release|x64.ActiveCfg = Release|Any CPU
+                {B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Release|x64.Build.0 = Release|Any CPU
+                {B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Release|x86.ActiveCfg = Release|Any CPU
+                {B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}.Release|x86.Build.0 = Release|Any CPU
+                {C65F0F41-E0CB-4919-8348-DB3AA8A4949F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {C65F0F41-E0CB-4919-8348-DB3AA8A4949F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {C65F0F41-E0CB-4919-8348-DB3AA8A4949F}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {C65F0F41-E0CB-4919-8348-DB3AA8A4949F}.Debug|x64.Build.0 = Debug|Any CPU
+                {C65F0F41-E0CB-4919-8348-DB3AA8A4949F}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {C65F0F41-E0CB-4919-8348-DB3AA8A4949F}.Debug|x86.Build.0 = Debug|Any CPU
+                {C65F0F41-E0CB-4919-8348-DB3AA8A4949F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {C65F0F41-E0CB-4919-8348-DB3AA8A4949F}.Release|Any CPU.Build.0 = Release|Any CPU
+                {C65F0F41-E0CB-4919-8348-DB3AA8A4949F}.Release|x64.ActiveCfg = Release|Any CPU
+                {C65F0F41-E0CB-4919-8348-DB3AA8A4949F}.Release|x64.Build.0 = Release|Any CPU
+                {C65F0F41-E0CB-4919-8348-DB3AA8A4949F}.Release|x86.ActiveCfg = Release|Any CPU
+                {C65F0F41-E0CB-4919-8348-DB3AA8A4949F}.Release|x86.Build.0 = Release|Any CPU
+                {1D73C601-A31A-4F59-A51B-D26E80292F7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {1D73C601-A31A-4F59-A51B-D26E80292F7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {1D73C601-A31A-4F59-A51B-D26E80292F7F}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {1D73C601-A31A-4F59-A51B-D26E80292F7F}.Debug|x64.Build.0 = Debug|Any CPU
+                {1D73C601-A31A-4F59-A51B-D26E80292F7F}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {1D73C601-A31A-4F59-A51B-D26E80292F7F}.Debug|x86.Build.0 = Debug|Any CPU
+                {1D73C601-A31A-4F59-A51B-D26E80292F7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {1D73C601-A31A-4F59-A51B-D26E80292F7F}.Release|Any CPU.Build.0 = Release|Any CPU
+                {1D73C601-A31A-4F59-A51B-D26E80292F7F}.Release|x64.ActiveCfg = Release|Any CPU
+                {1D73C601-A31A-4F59-A51B-D26E80292F7F}.Release|x64.Build.0 = Release|Any CPU
+                {1D73C601-A31A-4F59-A51B-D26E80292F7F}.Release|x86.ActiveCfg = Release|Any CPU
+                {1D73C601-A31A-4F59-A51B-D26E80292F7F}.Release|x86.Build.0 = Release|Any CPU
+                {21250535-58FB-4EBE-8A40-202D033FCEAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {21250535-58FB-4EBE-8A40-202D033FCEAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {21250535-58FB-4EBE-8A40-202D033FCEAD}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {21250535-58FB-4EBE-8A40-202D033FCEAD}.Debug|x64.Build.0 = Debug|Any CPU
+                {21250535-58FB-4EBE-8A40-202D033FCEAD}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {21250535-58FB-4EBE-8A40-202D033FCEAD}.Debug|x86.Build.0 = Debug|Any CPU
+                {21250535-58FB-4EBE-8A40-202D033FCEAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {21250535-58FB-4EBE-8A40-202D033FCEAD}.Release|Any CPU.Build.0 = Release|Any CPU
+                {21250535-58FB-4EBE-8A40-202D033FCEAD}.Release|x64.ActiveCfg = Release|Any CPU
+                {21250535-58FB-4EBE-8A40-202D033FCEAD}.Release|x64.Build.0 = Release|Any CPU
+                {21250535-58FB-4EBE-8A40-202D033FCEAD}.Release|x86.ActiveCfg = Release|Any CPU
+                {21250535-58FB-4EBE-8A40-202D033FCEAD}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
+        EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add new Domain, Application, and Infrastructure class library projects to the solution
- configure project references to enforce the desired layering and keep the API entry point focused on hosting
- move the WeatherForecast record into the Domain project so it can be reused across layers

## Testing
- not run (dotnet CLI unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dec9385f54832e84f06e8bb0365f57