### PR TITLE
feat: add product abstractions and DTOs to application layer

### DIFF
--- a/ProyectoBase.Application/Abstractions/IProductRepository.cs
+++ b/ProyectoBase.Application/Abstractions/IProductRepository.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ProyectoBase.Domain.Entities;
+
+namespace ProyectoBase.Application.Abstractions
+{
+    /// <summary>
+    /// Provides data access operations for <see cref="Product"/> entities.
+    /// </summary>
+    public interface IProductRepository
+    {
+        /// <summary>
+        /// Retrieves a product by its unique identifier.
+        /// </summary>
+        /// <param name="id">The identifier of the product to retrieve.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>The matching <see cref="Product"/> instance, if it exists.</returns>
+        Task<Product?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves all products available in the data store.
+        /// </summary>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A read-only collection containing the available products.</returns>
+        Task<IReadOnlyCollection<Product>> GetAllAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Persists a new product in the data store.
+        /// </summary>
+        /// <param name="product">The product to persist.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task AddAsync(Product product, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates an existing product in the data store.
+        /// </summary>
+        /// <param name="product">The product instance containing the updates.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task UpdateAsync(Product product, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a product from the data store.
+        /// </summary>
+        /// <param name="id">The identifier of the product to delete.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task DeleteAsync(Guid id, CancellationToken cancellationToken = default);
+    }
+}

--- a/ProyectoBase.Application/Abstractions/IProductService.cs
+++ b/ProyectoBase.Application/Abstractions/IProductService.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ProyectoBase.Application.DTOs;
+
+namespace ProyectoBase.Application.Abstractions
+{
+    /// <summary>
+    /// Defines the operations available to manage products within the application layer.
+    /// </summary>
+    public interface IProductService
+    {
+        /// <summary>
+        /// Creates a new product from the provided information.
+        /// </summary>
+        /// <param name="product">The data describing the product to create.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>The representation of the created product.</returns>
+        Task<ProductResponseDto> CreateAsync(ProductCreateDto product, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates an existing product using the supplied information.
+        /// </summary>
+        /// <param name="product">The data describing the product to update.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>The representation of the updated product.</returns>
+        Task<ProductResponseDto> UpdateAsync(ProductUpdateDto product, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves a product by its unique identifier.
+        /// </summary>
+        /// <param name="id">The identifier of the product to retrieve.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>The requested product representation, if it exists.</returns>
+        Task<ProductResponseDto?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves all products available in the application context.
+        /// </summary>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A collection containing the available product representations.</returns>
+        Task<IReadOnlyCollection<ProductResponseDto>> GetAllAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes the product that matches the provided identifier.
+        /// </summary>
+        /// <param name="id">The identifier of the product to remove.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        Task DeleteAsync(Guid id, CancellationToken cancellationToken = default);
+    }
+}

--- a/ProyectoBase.Application/Class1.cs
+++ b/ProyectoBase.Application/Class1.cs
@@ -1,5 +1,0 @@
-namespace ProyectoBase.Application;
-
-public class Class1
-{
-}

--- a/ProyectoBase.Application/DTOs/ProductCreateDto.cs
+++ b/ProyectoBase.Application/DTOs/ProductCreateDto.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ProyectoBase.Application.DTOs
+{
+    /// <summary>
+    /// Represents the data required to create a new product.
+    /// </summary>
+    public class ProductCreateDto
+    {
+        /// <summary>
+        /// Gets or sets the name of the product.
+        /// </summary>
+        [Required]
+        [StringLength(100, MinimumLength = 2)]
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the description of the product.
+        /// </summary>
+        [StringLength(500)]
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the price of the product.
+        /// </summary>
+        [Range(0.01, 999999.99)]
+        public decimal Price { get; set; }
+
+        /// <summary>
+        /// Gets or sets the available stock of the product.
+        /// </summary>
+        [Range(0, int.MaxValue)]
+        public int Stock { get; set; }
+    }
+}

--- a/ProyectoBase.Application/DTOs/ProductResponseDto.cs
+++ b/ProyectoBase.Application/DTOs/ProductResponseDto.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace ProyectoBase.Application.DTOs
+{
+    /// <summary>
+    /// Represents the product data returned by application services.
+    /// </summary>
+    public class ProductResponseDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier of the product.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the product.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the optional description of the product.
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the price of the product.
+        /// </summary>
+        public decimal Price { get; set; }
+
+        /// <summary>
+        /// Gets or sets the available stock of the product.
+        /// </summary>
+        public int Stock { get; set; }
+    }
+}

--- a/ProyectoBase.Application/DTOs/ProductUpdateDto.cs
+++ b/ProyectoBase.Application/DTOs/ProductUpdateDto.cs
@@ -1,0 +1,17 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ProyectoBase.Application.DTOs
+{
+    /// <summary>
+    /// Represents the information required to update an existing product.
+    /// </summary>
+    public class ProductUpdateDto : ProductCreateDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier of the product to update.
+        /// </summary>
+        [Required]
+        public Guid Id { get; set; }
+    }
+}

--- a/ProyectoBase.Application/ProyectoBase.Application.csproj
+++ b/ProyectoBase.Application/ProyectoBase.Application.csproj
@@ -3,8 +3,14 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ProyectoBase.Domain\ProyectoBase.Domain.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="11.9.0" />
+    <PackageReference Include="MediatR" Version="12.1.1" />
   </ItemGroup>
 </Project>

--- a/ProyectoBase.Application/Services/Products/CreateProductCommand.cs
+++ b/ProyectoBase.Application/Services/Products/CreateProductCommand.cs
@@ -1,0 +1,25 @@
+using MediatR;
+using ProyectoBase.Application.DTOs;
+
+namespace ProyectoBase.Application.Services.Products
+{
+    /// <summary>
+    /// Command used to request the creation of a new product.
+    /// </summary>
+    public class CreateProductCommand : IRequest<ProductResponseDto>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateProductCommand"/> class.
+        /// </summary>
+        /// <param name="product">The product data associated with the command.</param>
+        public CreateProductCommand(ProductCreateDto product)
+        {
+            Product = product;
+        }
+
+        /// <summary>
+        /// Gets the product data provided with the command.
+        /// </summary>
+        public ProductCreateDto Product { get; }
+    }
+}

--- a/ProyectoBase.Application/Services/Products/CreateProductCommandHandler.cs
+++ b/ProyectoBase.Application/Services/Products/CreateProductCommandHandler.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using ProyectoBase.Application.Abstractions;
+using ProyectoBase.Application.DTOs;
+
+namespace ProyectoBase.Application.Services.Products
+{
+    /// <summary>
+    /// Handles <see cref="CreateProductCommand"/> requests by delegating to the product service.
+    /// </summary>
+    public class CreateProductCommandHandler : IRequestHandler<CreateProductCommand, ProductResponseDto>
+    {
+        private readonly IProductService _productService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateProductCommandHandler"/> class.
+        /// </summary>
+        /// <param name="productService">The product service used to perform the operation.</param>
+        public CreateProductCommandHandler(IProductService productService)
+        {
+            _productService = productService;
+        }
+
+        /// <inheritdoc />
+        public Task<ProductResponseDto> Handle(CreateProductCommand request, CancellationToken cancellationToken)
+        {
+            return _productService.CreateAsync(request.Product, cancellationToken);
+        }
+    }
+}

--- a/ProyectoBase.Application/Validators/ProductCreateDtoValidator.cs
+++ b/ProyectoBase.Application/Validators/ProductCreateDtoValidator.cs
@@ -1,0 +1,31 @@
+using FluentValidation;
+using ProyectoBase.Application.DTOs;
+
+namespace ProyectoBase.Application.Validators
+{
+    /// <summary>
+    /// Validator that ensures <see cref="ProductCreateDto"/> instances contain valid data.
+    /// </summary>
+    public class ProductCreateDtoValidator : AbstractValidator<ProductCreateDto>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProductCreateDtoValidator"/> class.
+        /// </summary>
+        public ProductCreateDtoValidator()
+        {
+            RuleFor(product => product.Name)
+                .NotEmpty()
+                .Length(2, 100);
+
+            RuleFor(product => product.Description)
+                .MaximumLength(500);
+
+            RuleFor(product => product.Price)
+                .GreaterThan(0)
+                .LessThanOrEqualTo(999999.99m);
+
+            RuleFor(product => product.Stock)
+                .GreaterThanOrEqualTo(0);
+        }
+    }
+}

--- a/ProyectoBase.Application/Validators/ProductUpdateDtoValidator.cs
+++ b/ProyectoBase.Application/Validators/ProductUpdateDtoValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+using ProyectoBase.Application.DTOs;
+
+namespace ProyectoBase.Application.Validators
+{
+    /// <summary>
+    /// Validator that ensures <see cref="ProductUpdateDto"/> instances contain valid data.
+    /// </summary>
+    public class ProductUpdateDtoValidator : AbstractValidator<ProductUpdateDto>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProductUpdateDtoValidator"/> class.
+        /// </summary>
+        public ProductUpdateDtoValidator()
+        {
+            Include(new ProductCreateDtoValidator());
+
+            RuleFor(product => product.Id)
+                .NotEmpty();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add product repository and service abstractions with XML documentation
- introduce product DTOs, validators, and a MediatR command handler
- enable XML documentation and reference MediatR and FluentValidation packages

## Testing
- dotnet restore ProyectoBase.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68decac370d4832ebbc88b090d01e009