### PR TITLE
Implement infrastructure persistence layer

### DIFF
--- a/ProyectoBase.Infrastructure/Class1.cs
+++ b/ProyectoBase.Infrastructure/Class1.cs
@@ -1,5 +1,0 @@
-namespace ProyectoBase.Infrastructure;
-
-public class Class1
-{
-}

--- a/ProyectoBase.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/ProyectoBase.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using ProyectoBase.Domain.Entities;
+using ProyectoBase.Infrastructure.Persistence.Configurations;
+
+namespace ProyectoBase.Infrastructure.Persistence
+{
+    /// <summary>
+    /// Represents the Entity Framework Core database context responsible for managing
+    /// the persistence layer of the application.
+    /// </summary>
+    public class ApplicationDbContext : DbContext
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApplicationDbContext"/> class.
+        /// </summary>
+        /// <param name="options">The options to be used by the <see cref="DbContext"/>.</param>
+        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+            : base(options)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the set of <see cref="Product"/> entities tracked by the context.
+        /// </summary>
+        public DbSet<Product> Products { get; set; } = null!;
+
+        /// <summary>
+        /// Configures the model that maps the domain entities to the database schema.
+        /// </summary>
+        /// <param name="modelBuilder">The builder used to construct the model for the context.</param>
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.ApplyConfigurationsFromAssembly(typeof(ProductConfiguration).Assembly);
+        }
+    }
+}

--- a/ProyectoBase.Infrastructure/Persistence/Configurations/ProductConfiguration.cs
+++ b/ProyectoBase.Infrastructure/Persistence/Configurations/ProductConfiguration.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using ProyectoBase.Domain.Entities;
+
+namespace ProyectoBase.Infrastructure.Persistence.Configurations
+{
+    /// <summary>
+    /// Defines the entity framework mapping configuration for <see cref="Product"/> entities.
+    /// </summary>
+    public class ProductConfiguration : IEntityTypeConfiguration<Product>
+    {
+        /// <summary>
+        /// Configures the entity type builder with the mapping rules for the <see cref="Product"/> entity.
+        /// </summary>
+        /// <param name="builder">The builder that is used to configure the entity type.</param>
+        public void Configure(EntityTypeBuilder<Product> builder)
+        {
+            builder.ToTable("Products");
+
+            builder.HasKey(product => product.Id);
+
+            builder.Property(product => product.Name)
+                .IsRequired()
+                .HasMaxLength(200);
+
+            builder.Property(product => product.Description)
+                .HasMaxLength(500);
+
+            builder.Property(product => product.Price)
+                .HasColumnType("decimal(18,2)");
+
+            builder.Property(product => product.Stock)
+                .IsRequired();
+        }
+    }
+}

--- a/ProyectoBase.Infrastructure/Persistence/Repositories/ProductRepository.cs
+++ b/ProyectoBase.Infrastructure/Persistence/Repositories/ProductRepository.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ProyectoBase.Application.Abstractions;
+using ProyectoBase.Domain.Entities;
+
+namespace ProyectoBase.Infrastructure.Persistence.Repositories
+{
+    /// <summary>
+    /// Provides Entity Framework Core based persistence operations for <see cref="Product"/> entities.
+    /// </summary>
+    public class ProductRepository : IProductRepository
+    {
+        private readonly ApplicationDbContext _context;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProductRepository"/> class.
+        /// </summary>
+        /// <param name="context">The database context used to interact with the persistence store.</param>
+        public ProductRepository(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        /// <inheritdoc />
+        public async Task<Product?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        {
+            return await _context.Products
+                .AsNoTracking()
+                .FirstOrDefaultAsync(product => product.Id == id, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyCollection<Product>> GetAllAsync(CancellationToken cancellationToken = default)
+        {
+            var products = await _context.Products
+                .AsNoTracking()
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            return products.AsReadOnly();
+        }
+
+        /// <inheritdoc />
+        public async Task AddAsync(Product product, CancellationToken cancellationToken = default)
+        {
+            await _context.Products.AddAsync(product, cancellationToken).ConfigureAwait(false);
+            await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task UpdateAsync(Product product, CancellationToken cancellationToken = default)
+        {
+            _context.Products.Update(product);
+            await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+        {
+            var product = await _context.Products
+                .FirstOrDefaultAsync(entity => entity.Id == id, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (product is null)
+            {
+                return;
+            }
+
+            _context.Products.Remove(product);
+            await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/ProyectoBase.Infrastructure/ProyectoBase.Infrastructure.csproj
+++ b/ProyectoBase.Infrastructure/ProyectoBase.Infrastructure.csproj
@@ -3,7 +3,16 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ProyectoBase.Application\ProyectoBase.Application.csproj" />
     <ProjectReference Include="..\ProyectoBase.Domain\ProyectoBase.Domain.csproj" />


### PR DESCRIPTION
## Summary
- add Entity Framework Core dependencies and enable XML documentation for the infrastructure project
- implement the `ApplicationDbContext` along with the product entity configuration
- create an EF Core-backed `ProductRepository` that fulfills the application abstraction

## Testing
- not run (runtime unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68decb932720832ea5c64e6600df7d18