### PR TITLE
Add initial EF Core migration for product catalog

### DIFF
--- a/ProyectoBase.Infrastructure/Persistence/Migrations/20241010120000_InitialCreate.cs
+++ b/ProyectoBase.Infrastructure/Persistence/Migrations/20241010120000_InitialCreate.cs
@@ -1,0 +1,43 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ProyectoBase.Infrastructure.Persistence.Migrations
+{
+    /// <summary>
+    /// Defines the initial database schema for the application including the Products table.
+    /// </summary>
+    public partial class InitialCreate : Migration
+    {
+        /// <summary>
+        /// Builds the database objects required for the initial release of the application.
+        /// </summary>
+        /// <param name="migrationBuilder">The builder used to construct the database schema.</param>
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Products",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    Price = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    Stock = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Products", x => x.Id);
+                });
+        }
+
+        /// <summary>
+        /// Removes the database objects created in the <see cref="Up(MigrationBuilder)"/> method.
+        /// </summary>
+        /// <param name="migrationBuilder">The builder used to drop the database schema.</param>
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Products");
+        }
+    }
+}

--- a/ProyectoBase.Infrastructure/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/ProyectoBase.Infrastructure/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1,0 +1,52 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using ProyectoBase.Infrastructure.Persistence;
+
+namespace ProyectoBase.Infrastructure.Persistence.Migrations
+{
+    /// <summary>
+    /// Represents the Entity Framework Core model snapshot for the application database context.
+    /// </summary>
+    [DbContext(typeof(ApplicationDbContext))]
+    internal class ApplicationDbContextModelSnapshot : ModelSnapshot
+    {
+        /// <summary>
+        /// Builds the model used to generate database migrations.
+        /// </summary>
+        /// <param name="modelBuilder">The model builder used to configure the entity mappings.</param>
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+#pragma warning disable 612, 618
+            modelBuilder.HasAnnotation("ProductVersion", "9.0.9");
+
+            modelBuilder.Entity("ProyectoBase.Domain.Entities.Product", builder =>
+            {
+                builder.Property<Guid>("Id")
+                    .HasColumnType("uniqueidentifier");
+
+                builder.Property<string>("Description")
+                    .HasMaxLength(500)
+                    .HasColumnType("nvarchar(500)");
+
+                builder.Property<string>("Name")
+                    .IsRequired()
+                    .HasMaxLength(200)
+                    .HasColumnType("nvarchar(200)");
+
+                builder.Property<decimal>("Price")
+                    .HasColumnType("decimal(18,2)");
+
+                builder.Property<int>("Stock")
+                    .HasColumnType("int");
+
+                builder.HasKey("Id");
+
+                builder.ToTable("Products");
+            });
+#pragma warning restore 612, 618
+        }
+    }
+}

--- a/ProyectoBase.Infrastructure/ProyectoBase.Infrastructure.csproj
+++ b/ProyectoBase.Infrastructure/ProyectoBase.Infrastructure.csproj
@@ -17,4 +17,7 @@
     <ProjectReference Include="..\ProyectoBase.Application\ProyectoBase.Application.csproj" />
     <ProjectReference Include="..\ProyectoBase.Domain\ProyectoBase.Domain.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Persistence\Migrations\**\*.cs" />
+  </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ ng serve -o
 La aplicación se abrirá en http://localhost:4200
 ```
 
+### 🗄️ Migraciones de Entity Framework Core
+
+Para generar la migración inicial de la base de datos se debe ejecutar el siguiente comando desde la raíz del repositorio:
+
+```bash
+dotnet ef migrations add InitialCreate --project ProyectoBase.Infrastructure --startup-project ProyectoBase.Api --output-dir Persistence/Migrations
+```
+
+El comando utiliza el proyecto de infraestructura para almacenar las migraciones y el proyecto API como punto de entrada.
+
 🧩 Funcionalidad de ejemplo
 ```bash
 API (ProductsController)


### PR DESCRIPTION
## Summary
- add the initial Entity Framework Core migration and model snapshot for the product schema
- ensure infrastructure project includes migration sources in compilation
- document the EF Core migration command in the README for future execution

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68decc542168832eb551f3fdda275acb