### PR TITLE
Add environment-specific configuration and documentation

### DIFF
--- a/ProyectoBase.Api/.gitignore
+++ b/ProyectoBase.Api/.gitignore
@@ -273,8 +273,6 @@ FodyWeavers.xsd
 .env.local
 .env.development
 .env.production
-appsettings.Development.json
-appsettings.Local.json
 
 # Secrets
 secrets.json

--- a/ProyectoBase.Api/Options/ConnectionStringsOptions.cs
+++ b/ProyectoBase.Api/Options/ConnectionStringsOptions.cs
@@ -1,0 +1,9 @@
+namespace ProyectoBase.Api.Options;
+
+public class ConnectionStringsOptions
+{
+    public const string SectionName = "ConnectionStrings";
+    public const string DefaultConnectionName = "DefaultConnection";
+
+    public string DefaultConnection { get; set; } = string.Empty;
+}

--- a/ProyectoBase.Api/Options/JwtOptions.cs
+++ b/ProyectoBase.Api/Options/JwtOptions.cs
@@ -1,0 +1,14 @@
+namespace ProyectoBase.Api.Options;
+
+public class JwtOptions
+{
+    public const string SectionName = "Jwt";
+
+    public string Issuer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public string Secret { get; set; } = string.Empty;
+    public int AccessTokenExpirationMinutes { get; set; }
+        = 60;
+    public int RefreshTokenExpirationDays { get; set; }
+        = 7;
+}

--- a/ProyectoBase.Api/Options/RedisOptions.cs
+++ b/ProyectoBase.Api/Options/RedisOptions.cs
@@ -1,0 +1,9 @@
+namespace ProyectoBase.Api.Options;
+
+public class RedisOptions
+{
+    public const string SectionName = "Redis";
+
+    public string ConnectionString { get; set; } = string.Empty;
+    public string InstanceName { get; set; } = string.Empty;
+}

--- a/ProyectoBase.Api/Program.cs
+++ b/ProyectoBase.Api/Program.cs
@@ -1,15 +1,22 @@
-using ProyectoBase.Domain;
+using ProyectoBase.Api.Options;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services.Configure<JwtOptions>(builder.Configuration.GetSection(JwtOptions.SectionName));
+builder.Services.Configure<RedisOptions>(builder.Configuration.GetSection(RedisOptions.SectionName));
+builder.Services.Configure<ConnectionStringsOptions>(builder.Configuration.GetSection(ConnectionStringsOptions.SectionName));
+builder.Services.PostConfigure<ConnectionStringsOptions>(options =>
+{
+    options.DefaultConnection = builder.Configuration.GetConnectionString(ConnectionStringsOptions.DefaultConnectionName)
+        ?? options.DefaultConnection
+        ?? string.Empty;
+});
+
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
@@ -17,25 +24,5 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
-
-var summaries = new[]
-{
-    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
-
-app.MapGet("/weatherforecast", () =>
-{
-    var forecast =  Enumerable.Range(1, 5).Select(index =>
-        new WeatherForecast
-        (
-            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-            Random.Shared.Next(-20, 55),
-            summaries[Random.Shared.Next(summaries.Length)]
-        ))
-        .ToArray();
-    return forecast;
-})
-.WithName("GetWeatherForecast")
-.WithOpenApi();
 
 app.Run();

--- a/ProyectoBase.Api/appsettings.Development.json
+++ b/ProyectoBase.Api/appsettings.Development.json
@@ -1,0 +1,22 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Database=ProyectoBase;User Id=app;Password=ChangeThisPassword!;TrustServerCertificate=True;"
+  },
+  "Jwt": {
+    "Issuer": "ProyectoBase.Dev",
+    "Audience": "ProyectoBase.Dev.Clients",
+    "Secret": "ChangeThisDevelopmentSecret",
+    "AccessTokenExpirationMinutes": 60,
+    "RefreshTokenExpirationDays": 7
+  },
+  "Redis": {
+    "ConnectionString": "localhost:6379,abortConnect=false",
+    "InstanceName": "ProyectoBaseDev"
+  }
+}

--- a/ProyectoBase.Api/appsettings.Production.json
+++ b/ProyectoBase.Api/appsettings.Production.json
@@ -1,0 +1,22 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": ""
+  },
+  "Jwt": {
+    "Issuer": "",
+    "Audience": "",
+    "Secret": "",
+    "AccessTokenExpirationMinutes": 60,
+    "RefreshTokenExpirationDays": 7
+  },
+  "Redis": {
+    "ConnectionString": "",
+    "InstanceName": ""
+  }
+}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ ProyectoBase/
 ├── ProyectoBase.Api        # API en ASP.NET Core 8
 │   ├── Controllers         # Endpoints REST (ej: ProductsController)
 │   ├── Program.cs          # Configuración del pipeline
-│   └── appsettings.json    # Configuración (AllowedOrigins para CORS)
+│   ├── appsettings.json              # Configuración común
+│   ├── appsettings.Development.json  # Valores de desarrollo
+│   └── appsettings.Production.json   # Valores de producción
 │
 └── ProyectoBase.Web        # Frontend en Angular 14
     ├── src/app
@@ -43,6 +45,43 @@ Swagger: https://localhost:5001/swagger
 Endpoints: https://localhost:5001/api/products
 
 📌 CORS: se configura en appsettings.json (propiedad AllowedOrigins).
+
+### 🌍 Variables de entorno y configuración
+
+ASP.NET Core permite sobreescribir los archivos `appsettings*.json` mediante
+variables de entorno con el prefijo `DOTNET_`. Esto es especialmente útil en
+despliegues donde las credenciales no pueden vivir en el repositorio.
+
+Los nombres de las variables se construyen reemplazando los dos puntos (`:`)
+del `appsettings.json` por doble guion bajo (`__`). Ejemplos:
+
+```bash
+# Linux/macOS
+export DOTNET_ConnectionStrings__DefaultConnection="Server=sql;Database=ProyectoBase;User Id=api;Password=${DB_PASSWORD};TrustServerCertificate=True;"
+export DOTNET_Jwt__Issuer="https://api.midominio.com"
+export DOTNET_Jwt__Audience="ProyectoBase.Web"
+export DOTNET_Jwt__Secret="${JWT_SECRET}"
+export DOTNET_Redis__ConnectionString="redis:6379,abortConnect=false"
+export DOTNET_Redis__InstanceName="ProyectoBase"
+
+dotnet run --project ProyectoBase.Api
+
+# Windows PowerShell
+$env:DOTNET_ConnectionStrings__DefaultConnection = "Server=sql;Database=ProyectoBase;User Id=api;Password=$env:DB_PASSWORD;TrustServerCertificate=True;"
+$env:DOTNET_Jwt__Issuer = "https://api.midominio.com"
+$env:DOTNET_Jwt__Audience = "ProyectoBase.Web"
+$env:DOTNET_Jwt__Secret = $env:JWT_SECRET
+$env:DOTNET_Redis__ConnectionString = "redis:6379,abortConnect=false"
+$env:DOTNET_Redis__InstanceName = "ProyectoBase"
+
+dotnet run --project ProyectoBase.Api
+```
+
+Si la aplicación se despliega en contenedores (Docker/Kubernetes) o servicios
+gestionados (Azure App Service, AWS Elastic Beanstalk, etc.), basta con definir
+estas mismas variables en el entorno de ejecución para que `Program.cs`
+obtenga los valores en tiempo de arranque sin necesidad de modificarlos en el
+código fuente.
 
 ```
 ### 2. Frontend (Angular 14)


### PR DESCRIPTION
## Summary
- add environment-specific appsettings files for development and production with connection string, JWT, and Redis sections
- bind strongly typed options in Program.cs and remove hard-coded sample data
- document how to supply configuration through DOTNET_ environment variables during deployments

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68decceddcf4832eb74e1cd007f2c1ed