### PR TITLE
Add DI registration for application and infrastructure layers

### DIFF
--- a/ProyectoBase.Api/Program.cs
+++ b/ProyectoBase.Api/Program.cs
@@ -1,9 +1,14 @@
 using ProyectoBase.Api.Options;
+using ProyectoBase.Application;
+using ProyectoBase.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+builder.Services.AddApplication();
+builder.Services.AddInfrastructure(builder.Configuration);
 
 builder.Services.Configure<JwtOptions>(builder.Configuration.GetSection(JwtOptions.SectionName));
 builder.Services.Configure<RedisOptions>(builder.Configuration.GetSection(RedisOptions.SectionName));

--- a/ProyectoBase.Application/DependencyInjection.cs
+++ b/ProyectoBase.Application/DependencyInjection.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Reflection;
+using FluentValidation;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using ProyectoBase.Application.Abstractions;
+using ProyectoBase.Application.Services.Products;
+
+namespace ProyectoBase.Application;
+
+/// <summary>
+/// Provides extension methods to register application layer services within the dependency injection container.
+/// </summary>
+public static class DependencyInjection
+{
+    /// <summary>
+    /// Registers the application layer dependencies including services, validators and AutoMapper profiles.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The configured <see cref="IServiceCollection"/> instance.</returns>
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddMediatR(configuration =>
+        {
+            configuration.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly());
+        });
+
+        services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
+
+        services.AddAutoMapper(Assembly.GetExecutingAssembly());
+
+        services.AddScoped<IProductService, ProductService>();
+
+        return services;
+    }
+}

--- a/ProyectoBase.Application/Mapping/ProductProfile.cs
+++ b/ProyectoBase.Application/Mapping/ProductProfile.cs
@@ -1,0 +1,19 @@
+using AutoMapper;
+using ProyectoBase.Application.DTOs;
+using ProyectoBase.Domain.Entities;
+
+namespace ProyectoBase.Application.Mapping;
+
+/// <summary>
+/// Defines the mappings between product domain entities and DTOs.
+/// </summary>
+public class ProductProfile : Profile
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProductProfile"/> class.
+    /// </summary>
+    public ProductProfile()
+    {
+        CreateMap<Product, ProductResponseDto>();
+    }
+}

--- a/ProyectoBase.Application/ProyectoBase.Application.csproj
+++ b/ProyectoBase.Application/ProyectoBase.Application.csproj
@@ -12,5 +12,6 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.9.0" />
     <PackageReference Include="MediatR" Version="12.1.1" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
   </ItemGroup>
 </Project>

--- a/ProyectoBase.Application/Services/Products/ProductService.cs
+++ b/ProyectoBase.Application/Services/Products/ProductService.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using ProyectoBase.Application.Abstractions;
+using ProyectoBase.Application.DTOs;
+using ProyectoBase.Domain.Entities;
+using ProyectoBase.Domain.Exceptions;
+
+namespace ProyectoBase.Application.Services.Products;
+
+/// <summary>
+/// Provides application level operations to manage products.
+/// </summary>
+public class ProductService : IProductService
+{
+    private readonly IProductRepository _productRepository;
+    private readonly IMapper _mapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProductService"/> class.
+    /// </summary>
+    /// <param name="productRepository">The repository used to persist products.</param>
+    /// <param name="mapper">The mapper used to project entities into DTOs.</param>
+    public ProductService(IProductRepository productRepository, IMapper mapper)
+    {
+        _productRepository = productRepository;
+        _mapper = mapper;
+    }
+
+    /// <inheritdoc />
+    public async Task<ProductResponseDto> CreateAsync(ProductCreateDto product, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(product);
+
+        var entity = new Product(Guid.NewGuid(), product.Name, product.Price, product.Stock, product.Description);
+
+        await _productRepository.AddAsync(entity, cancellationToken).ConfigureAwait(false);
+
+        return _mapper.Map<ProductResponseDto>(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<ProductResponseDto> UpdateAsync(ProductUpdateDto product, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(product);
+
+        var entity = await _productRepository.GetByIdAsync(product.Id, cancellationToken).ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            throw new NotFoundException($"The product with id '{product.Id}' was not found.");
+        }
+
+        entity.UpdateName(product.Name);
+        entity.UpdateDescription(product.Description);
+        entity.ChangePrice(product.Price);
+
+        if (product.Stock != entity.Stock)
+        {
+            var difference = product.Stock - entity.Stock;
+
+            if (difference > 0)
+            {
+                entity.IncreaseStock(difference);
+            }
+            else
+            {
+                entity.DecreaseStock(Math.Abs(difference));
+            }
+        }
+
+        await _productRepository.UpdateAsync(entity, cancellationToken).ConfigureAwait(false);
+
+        return _mapper.Map<ProductResponseDto>(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<ProductResponseDto?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var product = await _productRepository.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
+
+        return product is null ? null : _mapper.Map<ProductResponseDto>(product);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyCollection<ProductResponseDto>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var products = await _productRepository.GetAllAsync(cancellationToken).ConfigureAwait(false);
+
+        var mapped = _mapper.Map<List<ProductResponseDto>>(products);
+
+        return mapped.Count == 0
+            ? Array.Empty<ProductResponseDto>()
+            : mapped.AsReadOnly();
+    }
+
+    /// <inheritdoc />
+    public Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return _productRepository.DeleteAsync(id, cancellationToken);
+    }
+}

--- a/ProyectoBase.Infrastructure/DependencyInjection.cs
+++ b/ProyectoBase.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,79 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.Registry;
+using ProyectoBase.Application.Abstractions;
+using ProyectoBase.Infrastructure.Persistence;
+using ProyectoBase.Infrastructure.Persistence.Repositories;
+
+namespace ProyectoBase.Infrastructure;
+
+/// <summary>
+/// Provides extension methods to register infrastructure services and dependencies.
+/// </summary>
+public static class DependencyInjection
+{
+    private const string DefaultConnectionName = "DefaultConnection";
+    private const string RetryPolicyName = "DefaultRetryPolicy";
+
+    /// <summary>
+    /// Registers the services required by the infrastructure layer.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="configuration">The application configuration source.</param>
+    /// <returns>The configured <see cref="IServiceCollection"/>.</returns>
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var connectionString = configuration.GetConnectionString(DefaultConnectionName);
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException($"Connection string '{DefaultConnectionName}' was not found.");
+        }
+
+        services.AddDbContext<ApplicationDbContext>(options =>
+        {
+            options.UseSqlServer(connectionString, sqlOptions =>
+            {
+                sqlOptions.EnableRetryOnFailure();
+            });
+        });
+
+        services.AddScoped<IProductRepository, ProductRepository>();
+
+        services.AddMemoryCache();
+        services.AddDistributedMemoryCache();
+        services.AddStackExchangeRedisCache(options =>
+        {
+            options.Configuration = configuration["Redis:ConnectionString"] ?? string.Empty;
+            options.InstanceName = configuration["Redis:InstanceName"] ?? string.Empty;
+        });
+
+        services.AddSingleton<IPolicyRegistry<string>>(provider =>
+        {
+            var logger = provider.GetRequiredService<ILoggerFactory>().CreateLogger("ResiliencePolicies");
+
+            var registry = new PolicyRegistry();
+
+            registry.Add(RetryPolicyName, Policy.Handle<Exception>().WaitAndRetryAsync(
+                retryCount: 3,
+                sleepDurationProvider: attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt - 1)),
+                onRetry: (exception, timeSpan, retryCount, context) =>
+                {
+                    logger.LogWarning(exception, "Retry {RetryCount} executed after {Delay} seconds.", retryCount, timeSpan.TotalSeconds);
+                }));
+
+            return registry;
+        });
+
+        services.AddSingleton<IReadOnlyPolicyRegistry<string>>(provider => provider.GetRequiredService<IPolicyRegistry<string>>());
+
+        return services;
+    }
+}

--- a/ProyectoBase.Infrastructure/ProyectoBase.Infrastructure.csproj
+++ b/ProyectoBase.Infrastructure/ProyectoBase.Infrastructure.csproj
@@ -12,6 +12,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.10" />
+    <PackageReference Include="Polly" Version="7.2.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ProyectoBase.Application\ProyectoBase.Application.csproj" />


### PR DESCRIPTION
## Summary
- add dependency injection extensions for the application and infrastructure projects
- implement the product application service and mapping profile used by the new registrations
- wire the new extensions into Program.cs and register persistence, caching, and resilience policies

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dece158cec832eaa893fe5694602e7