### PR TITLE
Integrate NLog logging pipeline

### DIFF
--- a/ProyectoBase.Api/Program.cs
+++ b/ProyectoBase.Api/Program.cs
@@ -1,9 +1,13 @@
+using NLog.Web;
 using ProyectoBase.Api.Middlewares;
 using ProyectoBase.Api.Options;
 using ProyectoBase.Application;
 using ProyectoBase.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Logging.ClearProviders();
+builder.Host.UseNLog();
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/ProyectoBase.Api/ProyectoBase.Api.csproj
+++ b/ProyectoBase.Api/ProyectoBase.Api.csproj
@@ -13,11 +13,18 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="NLog.Web.AspNetCore" Version="5.3.9" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ProyectoBase.Application\ProyectoBase.Application.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="nlog.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/ProyectoBase.Api/nlog.config
+++ b/ProyectoBase.Api/nlog.config
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      autoReload="true"
+      internalLogLevel="Warn"
+      internalLogFile="${basedir}/logs/internal-nlog.log">
+  <extensions>
+    <add assembly="NLog.Web.AspNetCore" />
+  </extensions>
+
+  <variable name="LogDirectory" value="${environment:variable=NLOG_LOG_DIRECTORY:whenEmpty=${basedir}/logs}" />
+  <variable name="MinLogLevel" value="${environment:variable=NLOG_MINLEVEL:whenEmpty=Info}" />
+  <variable name="SanitizePattern" value="(?i)(token|secret|password|apikey)(\s*[:=]\s*)([^\s\"',;]+)" />
+
+  <targets>
+    <target xsi:type="Console" name="console" detectConsoleAvailable="true">
+      <layout xsi:type="JsonLayout" includeAllProperties="false">
+        <attribute name="timestamp" layout="${longdate}" />
+        <attribute name="level" layout="${uppercase:${level}}" />
+        <attribute name="logger" layout="${logger}" />
+        <attribute name="message" layout="${replace:inner=${message:raw=true}:regex=${var:SanitizePattern}:replacement=${1}${2}***}" />
+        <attribute name="properties"
+                   layout="${replace:inner=${all-event-properties:format=Json}:regex=${var:SanitizePattern}:replacement=${1}${2}***}"
+                   includeEmptyValue="false" />
+        <attribute name="scopes" layout="${scopejson}" includeEmptyValue="false" />
+        <attribute name="requestId" layout="${aspnet-traceidentifier}" includeEmptyValue="false" />
+        <attribute name="requestPath" layout="${aspnet-request-url:IncludeQueryString=true}" includeEmptyValue="false" />
+        <attribute name="requestHeaders"
+                   layout="${replace:inner=${aspnet-request-headers:OutputFormat=Json}:regex=(?i)(authorization\"\s*:\s*\")(.*?)(\")|replacement=${1}***${3}}"
+                   includeEmptyValue="false" />
+        <attribute name="exception" layout="${exception:format=ToString}" includeEmptyValue="false" />
+      </layout>
+    </target>
+
+    <target xsi:type="File" name="file" fileName="${LogDirectory}/${shortdate}.log" concurrentWrites="false" keepFileOpen="false">
+      <layout xsi:type="JsonLayout" includeAllProperties="false">
+        <attribute name="timestamp" layout="${longdate}" />
+        <attribute name="level" layout="${uppercase:${level}}" />
+        <attribute name="logger" layout="${logger}" />
+        <attribute name="message" layout="${replace:inner=${message:raw=true}:regex=${var:SanitizePattern}:replacement=${1}${2}***}" />
+        <attribute name="properties"
+                   layout="${replace:inner=${all-event-properties:format=Json}:regex=${var:SanitizePattern}:replacement=${1}${2}***}"
+                   includeEmptyValue="false" />
+        <attribute name="scopes" layout="${scopejson}" includeEmptyValue="false" />
+        <attribute name="requestId" layout="${aspnet-traceidentifier}" includeEmptyValue="false" />
+        <attribute name="requestPath" layout="${aspnet-request-url:IncludeQueryString=true}" includeEmptyValue="false" />
+        <attribute name="requestHeaders"
+                   layout="${replace:inner=${aspnet-request-headers:OutputFormat=Json}:regex=(?i)(authorization\"\s*:\s*\")(.*?)(\")|replacement=${1}***${3}}"
+                   includeEmptyValue="false" />
+        <attribute name="exception" layout="${exception:format=ToString}" includeEmptyValue="false" />
+      </layout>
+    </target>
+  </targets>
+
+  <rules>
+    <logger name="*" minlevel="${var:MinLogLevel}" writeTo="console">
+      <filters>
+        <when condition="equals('${aspnet-environment}','Development')" action="Log" />
+        <default action="Ignore" />
+      </filters>
+    </logger>
+
+    <logger name="*" minlevel="${var:MinLogLevel}" writeTo="console,file">
+      <filters>
+        <when condition="equals('${aspnet-environment}','Staging')" action="Log" />
+        <default action="Ignore" />
+      </filters>
+    </logger>
+
+    <logger name="*" minlevel="${var:MinLogLevel}" writeTo="file">
+      <filters>
+        <when condition="equals('${aspnet-environment}','Production')" action="Log" />
+        <default action="Ignore" />
+      </filters>
+    </logger>
+
+    <logger name="*" minlevel="${var:MinLogLevel}" writeTo="console">
+      <filters>
+        <when condition="not(equals('${aspnet-environment}','Development') or equals('${aspnet-environment}','Staging') or equals('${aspnet-environment}','Production'))" action="Log" />
+        <default action="Ignore" />
+      </filters>
+    </logger>
+  </rules>
+</nlog>

--- a/README.md
+++ b/README.md
@@ -83,7 +83,52 @@ estas mismas variables en el entorno de ejecución para que `Program.cs`
 obtenga los valores en tiempo de arranque sin necesidad de modificarlos en el
 código fuente.
 
+### 📝 Logging con NLog
+
+La API reemplaza el proveedor por defecto de ASP.NET Core y utiliza **NLog**
+(`nlog.config` en `ProyectoBase.Api`) para centralizar los logs. Cada entorno
+tiene un destino distinto:
+
+- `Development`: salida estructurada en consola.
+- `Staging`: consola + archivo.
+- `Production`: solo archivo (`logs/<fecha>.log` por defecto).
+
+Todos los mensajes pasan por un layout que anonimiza tokens, contraseñas y
+valores sensibles detectados en mensajes, propiedades de log y cabeceras HTTP.
+
+#### 🔧 Sobrescribir configuración de NLog por variables de entorno
+
+Las variables declaradas en `nlog.config` permiten ajustar la configuración sin
+editar archivos:
+
+```bash
+# Cambiar el nivel mínimo de log
+export NLOG_MINLEVEL=Debug
+
+# Redefinir el directorio de logs
+export NLOG_LOG_DIRECTORY=/var/log/proyecto-base
+
+dotnet run --project ProyectoBase.Api
 ```
+
+Al iniciar la API, NLog leerá estas variables y adaptará los destinos de salida
+con la configuración indicada.
+
+#### ✅ Verificar logs de excepciones
+
+El `ExceptionHandlingMiddleware` se mantiene al inicio del pipeline, por lo que
+cualquier excepción no controlada termina en NLog con el formato anterior.
+
+```bash
+dotnet run --project ProyectoBase.Api
+
+# En otra terminal generar un 404 para revisar el log estructurado
+curl -k https://localhost:5001/api/products/99999
+```
+
+El middleware responde con un JSON estandarizado y el error queda registrado en
+la consola o archivo según el entorno, sin exponer credenciales.
+
 ### 2. Frontend (Angular 14)
 ```bash
 


### PR DESCRIPTION
## Summary
- add NLog.Web.AspNetCore to the API project and ship the nlog.config file with environment-specific targets and sensitive-data masking
- switch Program.cs to use the NLog logging provider
- document how to override NLog via environment variables and how to validate exception logging in the README

## Testing
- dotnet build ProyectoBase.Api/ProyectoBase.Api.csproj *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ded8050970832eabc1636e862ee408