### PR TITLE
Add versioned products controller and API versioning configuration

### DIFF
--- a/ProyectoBase.Api/Controllers/V1/ProductsController.cs
+++ b/ProyectoBase.Api/Controllers/V1/ProductsController.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using ProyectoBase.Application.Abstractions;
+using ProyectoBase.Application.DTOs;
+
+namespace ProyectoBase.Api.Controllers.V1;
+
+/// <summary>
+/// Exposes endpoints to manage products resources.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Produces("application/json")]
+[Route("api/v{version:apiVersion}/[controller]")]
+public class ProductsController : ControllerBase
+{
+    private readonly IProductService _productService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProductsController"/> class.
+    /// </summary>
+    /// <param name="productService">The service responsible for product operations.</param>
+    public ProductsController(IProductService productService)
+    {
+        _productService = productService;
+    }
+
+    /// <summary>
+    /// Retrieves the complete list of available products.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>A collection containing the requested products.</returns>
+    [HttpGet]
+    [ProducesResponseType(typeof(IReadOnlyCollection<ProductResponseDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<IReadOnlyCollection<ProductResponseDto>>> GetProductsAsync(CancellationToken cancellationToken)
+    {
+        var products = await _productService.GetAllAsync(cancellationToken).ConfigureAwait(false);
+
+        return Ok(products);
+    }
+
+    /// <summary>
+    /// Retrieves a specific product by its unique identifier.
+    /// </summary>
+    /// <param name="id">The identifier of the product to retrieve.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>The product that matches the provided identifier.</returns>
+    [HttpGet("{id:guid}")]
+    [ProducesResponseType(typeof(ProductResponseDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<ProductResponseDto>> GetProductByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var product = await _productService.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
+
+        if (product is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(product);
+    }
+
+    /// <summary>
+    /// Creates a new product using the provided information.
+    /// </summary>
+    /// <param name="product">The product information.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>The representation of the created product.</returns>
+    [HttpPost]
+    [ProducesResponseType(typeof(ProductResponseDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<ProductResponseDto>> CreateProductAsync([FromBody] ProductCreateDto product, CancellationToken cancellationToken)
+    {
+        var createdProduct = await _productService.CreateAsync(product, cancellationToken).ConfigureAwait(false);
+        var version = HttpContext.GetRequestedApiVersion()?.ToString() ?? "1.0";
+
+        return CreatedAtAction(nameof(GetProductByIdAsync), new { id = createdProduct.Id, version }, createdProduct);
+    }
+
+    /// <summary>
+    /// Updates the product that matches the provided identifier.
+    /// </summary>
+    /// <param name="id">The identifier of the product to update.</param>
+    /// <param name="product">The product data to apply.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>The representation of the updated product.</returns>
+    [HttpPut("{id:guid}")]
+    [ProducesResponseType(typeof(ProductResponseDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<ProductResponseDto>> UpdateProductAsync(Guid id, [FromBody] ProductUpdateDto product, CancellationToken cancellationToken)
+    {
+        if (product.Id != Guid.Empty && product.Id != id)
+        {
+            return BadRequest("The provided identifier does not match the route value.");
+        }
+
+        product.Id = id;
+
+        var updatedProduct = await _productService.UpdateAsync(product, cancellationToken).ConfigureAwait(false);
+
+        return Ok(updatedProduct);
+    }
+
+    /// <summary>
+    /// Deletes the product that matches the provided identifier.
+    /// </summary>
+    /// <param name="id">The identifier of the product to delete.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>A response indicating the result of the deletion.</returns>
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> DeleteProductAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var existingProduct = await _productService.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
+
+        if (existingProduct is null)
+        {
+            return NotFound();
+        }
+
+        await _productService.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
+
+        return NoContent();
+    }
+}

--- a/ProyectoBase.Api/Program.cs
+++ b/ProyectoBase.Api/Program.cs
@@ -1,3 +1,11 @@
+using System;
+using System.IO;
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Versioning;
+using Microsoft.OpenApi.Models;
+using Microsoft.Extensions.DependencyInjection;
 using NLog.Web;
 using ProyectoBase.Api.Middlewares;
 using ProyectoBase.Api.Options;
@@ -9,8 +17,42 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Logging.ClearProviders();
 builder.Host.UseNLog();
 
+builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = "ProyectoBase API",
+        Version = "v1",
+    });
+
+    var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+    var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFilename);
+
+    if (File.Exists(xmlPath))
+    {
+        options.IncludeXmlComments(xmlPath);
+    }
+});
+
+builder.Services.AddApiVersioning(options =>
+{
+    options.DefaultApiVersion = new ApiVersion(1, 0);
+    options.AssumeDefaultVersionWhenUnspecified = true;
+    options.ReportApiVersions = true;
+    options.ApiVersionReader = ApiVersionReader.Combine(
+        new QueryStringApiVersionReader("api-version"),
+        new HeaderApiVersionReader("x-api-version"),
+        new MediaTypeApiVersionReader("x-api-version"),
+        new UrlSegmentApiVersionReader());
+});
+
+builder.Services.AddVersionedApiExplorer(options =>
+{
+    options.GroupNameFormat = "'v'VVV";
+    options.SubstituteApiVersionInUrl = true;
+});
 
 builder.Services.AddApplication();
 builder.Services.AddInfrastructure(builder.Configuration);
@@ -30,11 +72,21 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
-    app.UseSwaggerUI();
+    var apiVersionProvider = app.Services.GetRequiredService<IApiVersionDescriptionProvider>();
+
+    app.UseSwaggerUI(options =>
+    {
+        foreach (var description in apiVersionProvider.ApiVersionDescriptions)
+        {
+            options.SwaggerEndpoint($"/swagger/{description.GroupName}/swagger.json", description.GroupName.ToUpperInvariant());
+        }
+    });
 }
 
 app.UseMiddleware<ExceptionHandlingMiddleware>();
 
 app.UseHttpsRedirection();
+
+app.MapControllers();
 
 app.Run();

--- a/ProyectoBase.Api/ProyectoBase.Api.csproj
+++ b/ProyectoBase.Api/ProyectoBase.Api.csproj
@@ -4,10 +4,14 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.20" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.9">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- configure API versioning, versioned API explorer, and Swagger UI integration
- enable XML documentation generation for the API project and add MVC versioning packages
- add a versioned v1 products controller that returns DTOs with documented response types

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68deda2c87c8832ea5826c98a7c58180