### PR TITLE
Add domain and API integration test projects with CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore ProyectoBase.sln
+
+      - name: Build
+        run: dotnet build ProyectoBase.sln --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test ProyectoBase.sln --no-build --configuration Release --verbosity normal

--- a/ProyectoBase.Api.IntegrationTests/Controllers/V1/ProductsControllerTests.cs
+++ b/ProyectoBase.Api.IntegrationTests/Controllers/V1/ProductsControllerTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using ProyectoBase.Api.IntegrationTests.Infrastructure;
+using ProyectoBase.Application.DTOs;
+using Xunit;
+
+namespace ProyectoBase.Api.IntegrationTests.Controllers.V1;
+
+public class ProductsControllerTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly CustomWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public ProductsControllerTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task GetProducts_ShouldReturnSeededProduct()
+    {
+        var response = await _client.GetAsync("/api/v1/Products").ConfigureAwait(false);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var products = await response.Content.ReadFromJsonAsync<List<ProductResponseDto>>().ConfigureAwait(false);
+
+        products.Should().NotBeNull();
+        products!.Should().ContainSingle();
+
+        var product = products.Single();
+        product.Id.Should().Be(_factory.SeededProductId);
+        product.Name.Should().Be("Integration Product");
+        product.Price.Should().Be(99.90m);
+    }
+
+    [Fact]
+    public async Task GetProductById_ShouldReturnExpectedProduct()
+    {
+        var response = await _client.GetAsync($"/api/v1/Products/{_factory.SeededProductId}").ConfigureAwait(false);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var product = await response.Content.ReadFromJsonAsync<ProductResponseDto>().ConfigureAwait(false);
+
+        product.Should().NotBeNull();
+        product!.Id.Should().Be(_factory.SeededProductId);
+        product.Name.Should().Be("Integration Product");
+    }
+
+    [Fact]
+    public async Task GetProductById_ShouldReturnNotFoundForUnknownProduct()
+    {
+        var response = await _client.GetAsync($"/api/v1/Products/{Guid.NewGuid()}").ConfigureAwait(false);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/ProyectoBase.Api.IntegrationTests/Infrastructure/CustomWebApplicationFactory.cs
+++ b/ProyectoBase.Api.IntegrationTests/Infrastructure/CustomWebApplicationFactory.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using ProyectoBase.Api;
+using ProyectoBase.Domain.Entities;
+using ProyectoBase.Infrastructure.Persistence;
+
+namespace ProyectoBase.Api.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Customizes the application factory to use an in-memory SQLite database for integration tests.
+/// </summary>
+public class CustomWebApplicationFactory : WebApplicationFactory<Program>
+{
+    /// <summary>
+    /// Gets the identifier of the product inserted during database seeding.
+    /// </summary>
+    public Guid SeededProductId { get; private set; }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration((_, configurationBuilder) =>
+        {
+            var settings = new Dictionary<string, string?>
+            {
+                ["Jwt:Key"] = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+                ["Jwt:Issuer"] = "IntegrationTests",
+                ["Jwt:Audience"] = "IntegrationTests",
+                ["ConnectionStrings:DefaultConnection"] = "Server=(localdb)\\mssqllocaldb;Database=IntegrationTests;Trusted_Connection=True;",
+                ["Redis:ConnectionString"] = "localhost",
+                ["Redis:InstanceName"] = "IntegrationTests",
+            };
+
+            configurationBuilder.AddInMemoryCollection(settings);
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            var dbContextDescriptor = services.SingleOrDefault(service => service.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+            if (dbContextDescriptor is not null)
+            {
+                services.Remove(dbContextDescriptor);
+            }
+
+            var applicationDbContextDescriptor = services.SingleOrDefault(service => service.ServiceType == typeof(ApplicationDbContext));
+            if (applicationDbContextDescriptor is not null)
+            {
+                services.Remove(applicationDbContextDescriptor);
+            }
+
+            var sqliteConnection = new SqliteConnection("DataSource=:memory:");
+            sqliteConnection.Open();
+
+            services.AddSingleton(sqliteConnection);
+
+            services.AddDbContext<ApplicationDbContext>((provider, options) =>
+            {
+                var connection = provider.GetRequiredService<SqliteConnection>();
+                options.UseSqlite(connection);
+            });
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            using var scope = serviceProvider.CreateScope();
+            var scopedServices = scope.ServiceProvider;
+            var context = scopedServices.GetRequiredService<ApplicationDbContext>();
+
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
+
+            SeedDatabase(context);
+        });
+    }
+
+    private void SeedDatabase(ApplicationDbContext context)
+    {
+        SeededProductId = Guid.NewGuid();
+
+        context.Products.RemoveRange(context.Products);
+
+        var product = new Product(SeededProductId, "Integration Product", 99.90m, 15, "Product used for integration tests.");
+
+        context.Products.Add(product);
+        context.SaveChanges();
+    }
+}

--- a/ProyectoBase.Api.IntegrationTests/ProyectoBase.Api.IntegrationTests.csproj
+++ b/ProyectoBase.Api.IntegrationTests/ProyectoBase.Api.IntegrationTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ProyectoBase.Api\ProyectoBase.Api.csproj" />
+    <ProjectReference Include="..\ProyectoBase.Application\ProyectoBase.Application.csproj" />
+    <ProjectReference Include="..\ProyectoBase.Domain\ProyectoBase.Domain.csproj" />
+    <ProjectReference Include="..\ProyectoBase.Infrastructure\ProyectoBase.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/ProyectoBase.Domain.Tests/Entities/ProductTests.cs
+++ b/ProyectoBase.Domain.Tests/Entities/ProductTests.cs
@@ -1,0 +1,57 @@
+using System;
+using FluentAssertions;
+using ProyectoBase.Domain.Entities;
+using ProyectoBase.Domain.Exceptions;
+using Xunit;
+
+namespace ProyectoBase.Domain.Tests.Entities;
+
+public class ProductTests
+{
+    [Fact]
+    public void Constructor_ShouldNormalizeAndAssignProvidedValues()
+    {
+        var id = Guid.NewGuid();
+        const string name = "  Gaming Laptop  ";
+        const string description = "  Powerful machine  ";
+        const decimal price = 1999.999m;
+        const int stock = 5;
+
+        var product = new Product(id, name, price, stock, description);
+
+        product.Id.Should().Be(id);
+        product.Name.Should().Be("Gaming Laptop");
+        product.Description.Should().Be("Powerful machine");
+        product.Price.Should().Be(2000.00m);
+        product.Stock.Should().Be(stock);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    public void IncreaseStock_ShouldThrowWhenQuantityIsNotPositive(int quantity)
+    {
+        var product = CreateProduct();
+
+        var action = () => product.IncreaseStock(quantity);
+
+        action.Should().Throw<ValidationException>()
+            .WithMessage("The quantity to increase must be greater than zero.");
+    }
+
+    [Fact]
+    public void DecreaseStock_ShouldThrowWhenQuantityExceedsAvailableStock()
+    {
+        var product = CreateProduct(stock: 2);
+
+        var action = () => product.DecreaseStock(5);
+
+        action.Should().Throw<ValidationException>()
+            .WithMessage("The quantity to decrease exceeds the available stock.");
+    }
+
+    private static Product CreateProduct(int stock = 10)
+    {
+        return new Product(Guid.NewGuid(), "Sample", 10m, stock, "Description");
+    }
+}

--- a/ProyectoBase.Domain.Tests/ProyectoBase.Domain.Tests.csproj
+++ b/ProyectoBase.Domain.Tests/ProyectoBase.Domain.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ProyectoBase.Domain\ProyectoBase.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/ProyectoBase.Domain.Tests/Services/ProductStockServiceTests.cs
+++ b/ProyectoBase.Domain.Tests/Services/ProductStockServiceTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using ProyectoBase.Domain.Entities;
+using ProyectoBase.Domain.Exceptions;
+using ProyectoBase.Domain.Repositories;
+using ProyectoBase.Domain.Services;
+using Xunit;
+
+namespace ProyectoBase.Domain.Tests.Services;
+
+public class ProductStockServiceTests
+{
+    private readonly Mock<IProductReadRepository> _repositoryMock = new();
+    private readonly ProductStockService _sut;
+
+    public ProductStockServiceTests()
+    {
+        _sut = new ProductStockService(_repositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task IsStockAvailableAsync_ShouldReturnTrueWhenQuantityIsAvailable()
+    {
+        var productId = Guid.NewGuid();
+        var product = new Product(productId, "Monitor", 150m, 10);
+        _repositoryMock.Setup(repository => repository.GetByIdAsync(productId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(product);
+
+        var result = await _sut.IsStockAvailableAsync(productId, 5, CancellationToken.None).ConfigureAwait(false);
+
+        result.Should().BeTrue();
+        _repositoryMock.Verify(repository => repository.GetByIdAsync(productId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task IsStockAvailableAsync_ShouldReturnFalseWhenQuantityIsNotAvailable()
+    {
+        var productId = Guid.NewGuid();
+        var product = new Product(productId, "Keyboard", 50m, 2);
+        _repositoryMock.Setup(repository => repository.GetByIdAsync(productId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(product);
+
+        var result = await _sut.IsStockAvailableAsync(productId, 3, CancellationToken.None).ConfigureAwait(false);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsStockAvailableAsync_ShouldThrowNotFoundExceptionWhenProductIsMissing()
+    {
+        var productId = Guid.NewGuid();
+        _repositoryMock.Setup(repository => repository.GetByIdAsync(productId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Product?)null);
+
+        var act = async () => await _sut.IsStockAvailableAsync(productId, 1, CancellationToken.None).ConfigureAwait(false);
+
+        await act.Should().ThrowAsync<NotFoundException>()
+            .WithMessage($"The product '{productId}' was not found.");
+    }
+
+    [Fact]
+    public async Task IsStockAvailableAsync_ShouldThrowValidationExceptionWhenQuantityIsNotPositive()
+    {
+        var productId = Guid.NewGuid();
+
+        var act = async () => await _sut.IsStockAvailableAsync(productId, 0, CancellationToken.None).ConfigureAwait(false);
+
+        await act.Should().ThrowAsync<ValidationException>()
+            .WithMessage("The quantity to check must be greater than zero.");
+
+        _repositoryMock.Verify(repository => repository.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/ProyectoBase.Domain/Repositories/IProductReadRepository.cs
+++ b/ProyectoBase.Domain/Repositories/IProductReadRepository.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ProyectoBase.Domain.Entities;
+
+namespace ProyectoBase.Domain.Repositories
+{
+    /// <summary>
+    /// Provides read-only access to <see cref="Product"/> entities from a persistence store.
+    /// </summary>
+    public interface IProductReadRepository
+    {
+        /// <summary>
+        /// Retrieves a product by its unique identifier.
+        /// </summary>
+        /// <param name="id">The identifier of the product to retrieve.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>The product that matches the provided identifier, or <c>null</c> if it does not exist.</returns>
+        Task<Product?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+    }
+}

--- a/ProyectoBase.Domain/Services/ProductStockService.cs
+++ b/ProyectoBase.Domain/Services/ProductStockService.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ProyectoBase.Domain.Entities;
+using ProyectoBase.Domain.Exceptions;
+using ProyectoBase.Domain.Repositories;
+
+namespace ProyectoBase.Domain.Services
+{
+    /// <summary>
+    /// Provides domain operations related to product stock availability.
+    /// </summary>
+    public class ProductStockService
+    {
+        private readonly IProductReadRepository _productRepository;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProductStockService"/> class.
+        /// </summary>
+        /// <param name="productRepository">The repository used to query products.</param>
+        public ProductStockService(IProductReadRepository productRepository)
+        {
+            ArgumentNullException.ThrowIfNull(productRepository);
+
+            _productRepository = productRepository;
+        }
+
+        /// <summary>
+        /// Determines whether a product has enough stock to satisfy the requested quantity.
+        /// </summary>
+        /// <param name="productId">The identifier of the product to evaluate.</param>
+        /// <param name="quantity">The quantity to verify.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns><c>true</c> when the requested quantity is available; otherwise, <c>false</c>.</returns>
+        /// <exception cref="NotFoundException">Thrown when the product cannot be found.</exception>
+        /// <exception cref="ValidationException">Thrown when the requested quantity is not greater than zero.</exception>
+        public async Task<bool> IsStockAvailableAsync(Guid productId, int quantity, CancellationToken cancellationToken)
+        {
+            if (quantity <= 0)
+            {
+                throw new ValidationException("The quantity to check must be greater than zero.");
+            }
+
+            var product = await _productRepository.GetByIdAsync(productId, cancellationToken).ConfigureAwait(false);
+
+            if (product is null)
+            {
+                throw new NotFoundException($"The product '{productId}' was not found.");
+            }
+
+            return product.Stock >= quantity;
+        }
+    }
+}

--- a/ProyectoBase.sln
+++ b/ProyectoBase.sln
@@ -12,6 +12,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Infrastructure
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Application.Tests", "ProyectoBase.Application.Tests\ProyectoBase.Application.Tests.csproj", "{DA44A544-1B76-4E7B-94E8-5607068DCE14}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Domain.Tests", "ProyectoBase.Domain.Tests\ProyectoBase.Domain.Tests.csproj", "{94E83EA3-E449-4F1B-8BF4-EA3EDF02107A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Api.IntegrationTests", "ProyectoBase.Api.IntegrationTests\ProyectoBase.Api.IntegrationTests.csproj", "{4F682FD9-F845-489D-B315-037F000E5173}"
+EndProject
 Global
         GlobalSection(SolutionConfigurationPlatforms) = preSolution
                 Debug|Any CPU = Debug|Any CPU
@@ -82,6 +86,30 @@ Global
                 {DA44A544-1B76-4E7B-94E8-5607068DCE14}.Release|x64.Build.0 = Release|Any CPU
                 {DA44A544-1B76-4E7B-94E8-5607068DCE14}.Release|x86.ActiveCfg = Release|Any CPU
                 {DA44A544-1B76-4E7B-94E8-5607068DCE14}.Release|x86.Build.0 = Release|Any CPU
+                {94E83EA3-E449-4F1B-8BF4-EA3EDF02107A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {94E83EA3-E449-4F1B-8BF4-EA3EDF02107A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {94E83EA3-E449-4F1B-8BF4-EA3EDF02107A}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {94E83EA3-E449-4F1B-8BF4-EA3EDF02107A}.Debug|x64.Build.0 = Debug|Any CPU
+                {94E83EA3-E449-4F1B-8BF4-EA3EDF02107A}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {94E83EA3-E449-4F1B-8BF4-EA3EDF02107A}.Debug|x86.Build.0 = Debug|Any CPU
+                {94E83EA3-E449-4F1B-8BF4-EA3EDF02107A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {94E83EA3-E449-4F1B-8BF4-EA3EDF02107A}.Release|Any CPU.Build.0 = Release|Any CPU
+                {94E83EA3-E449-4F1B-8BF4-EA3EDF02107A}.Release|x64.ActiveCfg = Release|Any CPU
+                {94E83EA3-E449-4F1B-8BF4-EA3EDF02107A}.Release|x64.Build.0 = Release|Any CPU
+                {94E83EA3-E449-4F1B-8BF4-EA3EDF02107A}.Release|x86.ActiveCfg = Release|Any CPU
+                {94E83EA3-E449-4F1B-8BF4-EA3EDF02107A}.Release|x86.Build.0 = Release|Any CPU
+                {4F682FD9-F845-489D-B315-037F000E5173}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {4F682FD9-F845-489D-B315-037F000E5173}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {4F682FD9-F845-489D-B315-037F000E5173}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {4F682FD9-F845-489D-B315-037F000E5173}.Debug|x64.Build.0 = Debug|Any CPU
+                {4F682FD9-F845-489D-B315-037F000E5173}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {4F682FD9-F845-489D-B315-037F000E5173}.Debug|x86.Build.0 = Debug|Any CPU
+                {4F682FD9-F845-489D-B315-037F000E5173}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {4F682FD9-F845-489D-B315-037F000E5173}.Release|Any CPU.Build.0 = Release|Any CPU
+                {4F682FD9-F845-489D-B315-037F000E5173}.Release|x64.ActiveCfg = Release|Any CPU
+                {4F682FD9-F845-489D-B315-037F000E5173}.Release|x64.Build.0 = Release|Any CPU
+                {4F682FD9-F845-489D-B315-037F000E5173}.Release|x86.ActiveCfg = Release|Any CPU
+                {4F682FD9-F845-489D-B315-037F000E5173}.Release|x86.Build.0 = Release|Any CPU
         EndGlobalSection
         GlobalSection(SolutionProperties) = preSolution
                 HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -181,6 +181,20 @@ Node.js 16/18 → Descargar aquí https://nodejs.org/en/
 
 Angular CLI 14 → instalar con: npm install -g @angular/cli@14
 ```
+
+### 🧪 Pruebas automatizadas
+
+Ejecuta toda la suite (unitarias y de integración) desde la raíz del repositorio:
+
+```bash
+dotnet test ProyectoBase.sln
+```
+
+Este comando incluye:
+
+- `ProyectoBase.Domain.Tests`: pruebas de dominio con **FluentAssertions** y mocks de repositorios utilizando **Moq**.
+- `ProyectoBase.Api.IntegrationTests`: pruebas de integración que levantan la API mediante `WebApplicationFactory<Program>` y una base de datos SQLite en memoria.
+
 📌 Próximos pasos
 ```
 Integrar base de datos (EF Core o Dapper).


### PR DESCRIPTION
## Summary
- add a domain services test suite with FluentAssertions and Moq
- introduce API integration tests powered by WebApplicationFactory and SQLite
- document the consolidated `dotnet test` command and add a CI workflow to run it

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68dee35ac00c832e99ca722b41171af4