### PR TITLE
Sanitize logged request metadata to avoid leaking sensitive data

### DIFF
--- a/ProyectoBase.Api.IntegrationTests/Logging/SafeRequestHeadersLayoutRendererTests.cs
+++ b/ProyectoBase.Api.IntegrationTests/Logging/SafeRequestHeadersLayoutRendererTests.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using ProyectoBase.Api.Logging;
+using Xunit;
+
+namespace ProyectoBase.Api.IntegrationTests.Logging;
+
+public sealed class SafeRequestHeadersLayoutRendererTests
+{
+    [Fact]
+    public void Render_MasksSensitiveHeaders()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.Add("Authorization", new StringValues("Bearer super-secret-token"));
+        httpContext.Request.Headers.Add("X-Api-Key", new StringValues("apikey-123"));
+        httpContext.Request.Headers.Add("X-Correlation-Id", new StringValues("correlation"));
+
+        var sanitized = SafeRequestHeadersLayoutRenderer.SanitizeHeaders(httpContext);
+
+        var serialized = JsonSerializer.Serialize(sanitized);
+        var json = JsonNode.Parse(serialized)!.AsObject();
+        json["Authorization"]!.GetValue<string>().Should().Be("***");
+        json["X-Api-Key"]!.GetValue<string>().Should().Be("***");
+        json["X-Correlation-Id"]!.GetValue<string>().Should().Be("correlation");
+        serialized.Should().NotContain("super-secret-token", because: "tokens must never be logged");
+    }
+
+    [Fact]
+    public void Render_MasksSensitiveValuesEvenForNonSensitiveHeaders()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.Add("X-Custom", new StringValues("password=PlainText"));
+
+        var sanitized = SafeRequestHeadersLayoutRenderer.SanitizeHeaders(httpContext);
+
+        var serialized = JsonSerializer.Serialize(sanitized);
+        var json = JsonNode.Parse(serialized)!.AsObject();
+        json["X-Custom"]!.GetValue<string>().Should().Be("***");
+    }
+}

--- a/ProyectoBase.Api.IntegrationTests/Logging/SafeUserClaimsLayoutRendererTests.cs
+++ b/ProyectoBase.Api.IntegrationTests/Logging/SafeUserClaimsLayoutRendererTests.cs
@@ -1,0 +1,50 @@
+using System.Security.Claims;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using ProyectoBase.Api.Logging;
+using Xunit;
+
+namespace ProyectoBase.Api.IntegrationTests.Logging;
+
+public sealed class SafeUserClaimsLayoutRendererTests
+{
+    [Fact]
+    public void Render_ReturnsClaimTypeCounts()
+    {
+        var httpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, "user-123"),
+                new Claim(ClaimTypes.Email, "person@example.com"),
+                new Claim(ClaimTypes.Role, "admin"),
+                new Claim(ClaimTypes.Role, "auditor"),
+            }, authenticationType: "Test")),
+        };
+
+        var claimsByType = SafeUserClaimsLayoutRenderer.GetClaimTypeCounts(httpContext);
+
+        var serialized = JsonSerializer.Serialize(claimsByType);
+        var json = JsonNode.Parse(serialized)!.AsObject();
+        json[ClaimTypes.NameIdentifier]!.GetValue<int>().Should().Be(1);
+        json[ClaimTypes.Email]!.GetValue<int>().Should().Be(1);
+        json[ClaimTypes.Role]!.GetValue<int>().Should().Be(2);
+        serialized.Should().NotContain("person@example.com", because: "emails must never be logged");
+        serialized.Should().NotContain("user-123");
+    }
+
+    [Fact]
+    public void Render_ReturnsEmptyWhenUserIsUnauthenticated()
+    {
+        var httpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity()),
+        };
+
+        var claimsByType = SafeUserClaimsLayoutRenderer.GetClaimTypeCounts(httpContext);
+
+        claimsByType.Should().BeEmpty();
+    }
+}

--- a/ProyectoBase.Api/Logging/SafeRequestHeadersLayoutRenderer.cs
+++ b/ProyectoBase.Api/Logging/SafeRequestHeadersLayoutRenderer.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using NLog;
+using NLog.LayoutRenderers;
+using NLog.Web.LayoutRenderers;
+
+namespace ProyectoBase.Api.Logging;
+
+/// <summary>
+/// Layout renderer that outputs HTTP request headers while masking sensitive values.
+/// </summary>
+[LayoutRenderer("safe-request-headers")]
+public sealed class SafeRequestHeadersLayoutRenderer : AspNetLayoutRendererBase
+{
+    private const string Mask = "***";
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private static readonly ISet<string> SensitiveHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "Authorization",
+        "Proxy-Authorization",
+        "Cookie",
+        "Set-Cookie",
+        "X-Api-Key",
+        "X-Amzn-Trace-Id",
+    };
+
+    private static readonly Regex[] SensitiveValuePatterns =
+    {
+        new("(?i)(token|secret|password|apikey|sessionid)[^a-z0-9]*[a-z0-9]+", RegexOptions.Compiled),
+        new("(?i)bearer\\s+[a-z0-9\-_.]+", RegexOptions.Compiled),
+        new("(?i)basic\\s+[a-z0-9+/=]+", RegexOptions.Compiled),
+    };
+
+    /// <summary>
+    /// Appends the sanitized headers to the log builder.
+    /// </summary>
+    /// <param name="builder">The builder receiving the rendered output.</param>
+    /// <param name="logEvent">The log event being processed.</param>
+    protected override void DoAppend(StringBuilder builder, LogEventInfo logEvent)
+    {
+        var sanitized = SanitizeHeaders(HttpContextAccessor?.HttpContext);
+        if (sanitized.Count == 0)
+        {
+            return;
+        }
+
+        builder.Append(JsonSerializer.Serialize(sanitized, JsonOptions));
+    }
+
+    /// <summary>
+    /// Produces a sanitized snapshot of the headers contained in the provided HTTP context.
+    /// </summary>
+    /// <param name="httpContext">The current HTTP context.</param>
+    /// <returns>A dictionary with sensitive information masked.</returns>
+    internal static IReadOnlyDictionary<string, string> SanitizeHeaders(HttpContext? httpContext)
+    {
+        if (httpContext?.Request?.Headers is null || httpContext.Request.Headers.Count == 0)
+        {
+            return EmptyHeaders;
+        }
+
+        var sanitized = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var header in httpContext.Request.Headers)
+        {
+            sanitized[header.Key] = SanitizeHeader(header.Key, header.Value);
+        }
+
+        return sanitized.Count == 0
+            ? EmptyHeaders
+            : sanitized;
+    }
+
+    /// <summary>
+    /// Gets a reusable empty dictionary instance to avoid unnecessary allocations.
+    /// </summary>
+    private static IReadOnlyDictionary<string, string> EmptyHeaders { get; } =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+    private static string SanitizeHeader(string name, StringValues value)
+    {
+        if (SensitiveHeaders.Contains(name))
+        {
+            return Mask;
+        }
+
+        var concatenated = string.Join(", ", value.ToArray());
+        if (string.IsNullOrWhiteSpace(concatenated))
+        {
+            return concatenated;
+        }
+
+        if (SensitiveValuePatterns.Any(pattern => pattern.IsMatch(concatenated)))
+        {
+            return Mask;
+        }
+
+        return concatenated;
+    }
+}

--- a/ProyectoBase.Api/Logging/SafeUserClaimsLayoutRenderer.cs
+++ b/ProyectoBase.Api/Logging/SafeUserClaimsLayoutRenderer.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using NLog;
+using NLog.LayoutRenderers;
+using NLog.Web.LayoutRenderers;
+
+namespace ProyectoBase.Api.Logging;
+
+/// <summary>
+/// Layout renderer that exposes authenticated user claims without leaking personal information.
+/// </summary>
+[LayoutRenderer("safe-user-claims")]
+public sealed class SafeUserClaimsLayoutRenderer : AspNetLayoutRendererBase
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// Appends sanitized claim information to the provided string builder.
+    /// </summary>
+    /// <param name="builder">The builder receiving the rendered output.</param>
+    /// <param name="logEvent">The log event being processed.</param>
+    protected override void DoAppend(StringBuilder builder, LogEventInfo logEvent)
+    {
+        var claimsByType = GetClaimTypeCounts(HttpContextAccessor?.HttpContext);
+        if (claimsByType.Count == 0)
+        {
+            return;
+        }
+
+        builder.Append(JsonSerializer.Serialize(claimsByType, JsonOptions));
+    }
+
+    /// <summary>
+    /// Aggregates authenticated user claims by type masking their actual values.
+    /// </summary>
+    /// <param name="httpContext">The HTTP context supplying the claims.</param>
+    /// <returns>A dictionary containing claim type counts.</returns>
+    internal static IReadOnlyDictionary<string, int> GetClaimTypeCounts(HttpContext? httpContext)
+    {
+        if (httpContext?.User?.Identity?.IsAuthenticated != true)
+        {
+            return EmptyClaims;
+        }
+
+        var claimsByType = httpContext.User.Claims
+            .GroupBy(claim => claim.Type, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+
+        return claimsByType.Count == 0
+            ? EmptyClaims
+            : claimsByType;
+    }
+
+    /// <summary>
+    /// Gets a reusable empty dictionary instance to avoid unnecessary allocations.
+    /// </summary>
+    private static IReadOnlyDictionary<string, int> EmptyClaims { get; } =
+        new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+}

--- a/ProyectoBase.Api/Properties/AssemblyInfo.cs
+++ b/ProyectoBase.Api/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ProyectoBase.Api.IntegrationTests")]

--- a/ProyectoBase.Api/nlog.config
+++ b/ProyectoBase.Api/nlog.config
@@ -6,6 +6,7 @@
       internalLogFile="${basedir}/logs/internal-nlog.log">
   <extensions>
     <add assembly="NLog.Web.AspNetCore" />
+    <add assembly="ProyectoBase.Api" />
   </extensions>
 
   <variable name="LogDirectory" value="${environment:variable=NLOG_LOG_DIRECTORY:whenEmpty=${basedir}/logs}" />
@@ -24,10 +25,11 @@
                    includeEmptyValue="false" />
         <attribute name="scopes" layout="${scopejson}" includeEmptyValue="false" />
         <attribute name="requestId" layout="${aspnet-traceidentifier}" includeEmptyValue="false" />
-        <attribute name="requestPath" layout="${aspnet-request-url:IncludeQueryString=true}" includeEmptyValue="false" />
+        <attribute name="requestPath" layout="${aspnet-request-url:IncludeQueryString=false}" includeEmptyValue="false" />
         <attribute name="requestHeaders"
-                   layout="${replace:inner=${aspnet-request-headers:OutputFormat=Json}:regex=(?i)(authorization\"\s*:\s*\")(.*?)(\")|replacement=${1}***${3}}"
+                   layout="${safe-request-headers}"
                    includeEmptyValue="false" />
+        <attribute name="userClaims" layout="${safe-user-claims}" includeEmptyValue="false" />
         <attribute name="exception" layout="${exception:format=ToString}" includeEmptyValue="false" />
       </layout>
     </target>
@@ -43,10 +45,11 @@
                    includeEmptyValue="false" />
         <attribute name="scopes" layout="${scopejson}" includeEmptyValue="false" />
         <attribute name="requestId" layout="${aspnet-traceidentifier}" includeEmptyValue="false" />
-        <attribute name="requestPath" layout="${aspnet-request-url:IncludeQueryString=true}" includeEmptyValue="false" />
+        <attribute name="requestPath" layout="${aspnet-request-url:IncludeQueryString=false}" includeEmptyValue="false" />
         <attribute name="requestHeaders"
-                   layout="${replace:inner=${aspnet-request-headers:OutputFormat=Json}:regex=(?i)(authorization\"\s*:\s*\")(.*?)(\")|replacement=${1}***${3}}"
+                   layout="${safe-request-headers}"
                    includeEmptyValue="false" />
+        <attribute name="userClaims" layout="${safe-user-claims}" includeEmptyValue="false" />
         <attribute name="exception" layout="${exception:format=ToString}" includeEmptyValue="false" />
       </layout>
     </target>

--- a/README.md
+++ b/README.md
@@ -129,6 +129,22 @@ curl -k https://localhost:5001/api/products/99999
 El middleware responde con un JSON estandarizado y el error queda registrado en
 la consola o archivo según el entorno, sin exponer credenciales.
 
+#### 🔐 Política de logging seguro
+
+- Las cabeceras HTTP se serializan mediante un layout renderer personalizado que
+  sustituye por `***` cualquier valor asociado a tokens (`Authorization`,
+  `Cookie`, `X-Api-Key`, etc.) o cadenas que contengan contraseñas.
+- Los claims del usuario autenticado solo se registran por tipo y cantidad,
+  evitando exponer identificadores, correos o valores sensibles.
+- Las rutas registradas excluyen el query string para impedir que parámetros con
+  secretos queden en los logs.
+- Los mensajes y propiedades del evento pasan por un filtro regex que enmascara
+  palabras clave comunes como `token`, `password`, `apikey` o `secret`.
+- Las pruebas automatizadas (`SafeRequestHeadersLayoutRendererTests` y
+  `SafeUserClaimsLayoutRendererTests`) actúan como guardias de regresión para
+  asegurar que los cambios futuros no vuelvan a introducir datos sensibles en
+  el logging.
+
 ### 2. Frontend (Angular 14)
 ```bash
 


### PR DESCRIPTION
## Summary
- add custom NLog layout renderers that redact sensitive headers and aggregate user claims without exposing values
- update nlog.config to use the new layout renderers, drop query strings from request paths, and document the secure logging policy
- add regression tests that verify sanitized headers and claims along with assembly visibility for testing helpers

## Testing
- `dotnet test` *(fails: command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dee80cffcc832ebe6ceff8af0c0575