### PR TITLE
Temporarily disable CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+# Workflow temporalmente deshabilitado mientras se actualiza la infraestructura de CI.
 name: CI
 
 on:
@@ -8,6 +9,8 @@ on:
 
 jobs:
   build-and-test:
+    # Condición fija para evitar que el workflow se ejecute hasta completar la revisión.
+    if: ${{ false }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- document the temporary CI suspension directly in the workflow file
- guard the build-and-test job with a false condition to prevent runs

## Testing
- not run (workflow configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68deec19a524832ebd94709bdec9724b