### PR TITLE
Localizar documentación y mensajes en español

### DIFF
--- a/Backend/ProyectoBase.Api/Controllers/V1/ProductsController.cs
+++ b/Backend/ProyectoBase.Api/Controllers/V1/ProductsController.cs
@@ -11,7 +11,7 @@ using ProyectoBase.Application.DTOs;
 namespace ProyectoBase.Api.Controllers.V1;
 
 /// <summary>
-/// Exposes endpoints to manage products resources.
+/// Expone endpoints para administrar recursos de productos.
 /// </summary>
 [ApiController]
 [ApiVersion("1.0")]
@@ -22,19 +22,19 @@ public class ProductsController : ControllerBase
     private readonly IProductService _productService;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ProductsController"/> class.
+    /// Inicializa una nueva instancia de la clase <see cref="ProductsController"/>.
     /// </summary>
-    /// <param name="productService">The service responsible for product operations.</param>
+    /// <param name="productService">El servicio responsable de las operaciones de productos.</param>
     public ProductsController(IProductService productService)
     {
         _productService = productService;
     }
 
     /// <summary>
-    /// Retrieves the complete list of available products.
+    /// Recupera la lista completa de productos disponibles.
     /// </summary>
-    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-    /// <returns>A collection containing the requested products.</returns>
+    /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+    /// <returns>Una colección con los productos solicitados.</returns>
     [HttpGet]
     [ProducesResponseType(typeof(IReadOnlyCollection<ProductResponseDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -46,11 +46,11 @@ public class ProductsController : ControllerBase
     }
 
     /// <summary>
-    /// Retrieves a specific product by its unique identifier.
+    /// Recupera un producto específico por su identificador único.
     /// </summary>
-    /// <param name="id">The identifier of the product to retrieve.</param>
-    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-    /// <returns>The product that matches the provided identifier.</returns>
+    /// <param name="id">El identificador del producto que se desea obtener.</param>
+    /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+    /// <returns>El producto que coincide con el identificador proporcionado.</returns>
     [HttpGet("{id:guid}")]
     [ProducesResponseType(typeof(ProductResponseDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -68,11 +68,11 @@ public class ProductsController : ControllerBase
     }
 
     /// <summary>
-    /// Creates a new product using the provided information.
+    /// Crea un nuevo producto con la información proporcionada.
     /// </summary>
-    /// <param name="product">The product information.</param>
-    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-    /// <returns>The representation of the created product.</returns>
+    /// <param name="product">La información del producto.</param>
+    /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+    /// <returns>La representación del producto creado.</returns>
     [HttpPost]
     [Authorize(Roles = "Admin")]
     [ProducesResponseType(typeof(ProductResponseDto), StatusCodes.Status201Created)]
@@ -86,12 +86,12 @@ public class ProductsController : ControllerBase
     }
 
     /// <summary>
-    /// Updates the product that matches the provided identifier.
+    /// Actualiza el producto que coincide con el identificador proporcionado.
     /// </summary>
-    /// <param name="id">The identifier of the product to update.</param>
-    /// <param name="product">The product data to apply.</param>
-    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-    /// <returns>The representation of the updated product.</returns>
+    /// <param name="id">El identificador del producto que se desea actualizar.</param>
+    /// <param name="product">Los datos del producto que se aplicarán.</param>
+    /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+    /// <returns>La representación del producto actualizado.</returns>
     [HttpPut("{id:guid}")]
     [Authorize(Roles = "Admin")]
     [ProducesResponseType(typeof(ProductResponseDto), StatusCodes.Status200OK)]
@@ -101,7 +101,7 @@ public class ProductsController : ControllerBase
     {
         if (product.Id != Guid.Empty && product.Id != id)
         {
-            return BadRequest("The provided identifier does not match the route value.");
+            return BadRequest("El identificador proporcionado no coincide con el valor de la ruta.");
         }
 
         product.Id = id;
@@ -112,11 +112,11 @@ public class ProductsController : ControllerBase
     }
 
     /// <summary>
-    /// Deletes the product that matches the provided identifier.
+    /// Elimina el producto que coincide con el identificador proporcionado.
     /// </summary>
-    /// <param name="id">The identifier of the product to delete.</param>
-    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-    /// <returns>A response indicating the result of the deletion.</returns>
+    /// <param name="id">El identificador del producto que se eliminará.</param>
+    /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+    /// <returns>Una respuesta que indica el resultado de la eliminación.</returns>
     [HttpDelete("{id:guid}")]
     [Authorize(Roles = "Admin")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]

--- a/Backend/ProyectoBase.Api/Logging/SafeRequestHeadersLayoutRenderer.cs
+++ b/Backend/ProyectoBase.Api/Logging/SafeRequestHeadersLayoutRenderer.cs
@@ -12,7 +12,7 @@ using NLog.Web.LayoutRenderers;
 namespace ProyectoBase.Api.Logging;
 
 /// <summary>
-/// Layout renderer that outputs HTTP request headers while masking sensitive values.
+/// Representa un layout renderer que emite los encabezados de la solicitud HTTP ocultando los valores sensibles.
 /// </summary>
 [LayoutRenderer("safe-request-headers")]
 public sealed class SafeRequestHeadersLayoutRenderer : AspNetLayoutRendererBase
@@ -39,10 +39,10 @@ public sealed class SafeRequestHeadersLayoutRenderer : AspNetLayoutRendererBase
     };
 
     /// <summary>
-    /// Appends the sanitized headers to the log builder.
+    /// Agrega los encabezados saneados al generador del registro.
     /// </summary>
-    /// <param name="builder">The builder receiving the rendered output.</param>
-    /// <param name="logEvent">The log event being processed.</param>
+    /// <param name="builder">El generador que recibe la salida renderizada.</param>
+    /// <param name="logEvent">El evento de registro que se está procesando.</param>
     protected override void DoAppend(StringBuilder builder, LogEventInfo logEvent)
     {
         var sanitized = SanitizeHeaders(HttpContextAccessor?.HttpContext);
@@ -55,10 +55,10 @@ public sealed class SafeRequestHeadersLayoutRenderer : AspNetLayoutRendererBase
     }
 
     /// <summary>
-    /// Produces a sanitized snapshot of the headers contained in the provided HTTP context.
+    /// Produce una instantánea saneada de los encabezados presentes en el contexto HTTP suministrado.
     /// </summary>
-    /// <param name="httpContext">The current HTTP context.</param>
-    /// <returns>A dictionary with sensitive information masked.</returns>
+    /// <param name="httpContext">El contexto HTTP actual.</param>
+    /// <returns>Un diccionario con la información sensible enmascarada.</returns>
     internal static IReadOnlyDictionary<string, string> SanitizeHeaders(HttpContext? httpContext)
     {
         if (httpContext?.Request?.Headers is null || httpContext.Request.Headers.Count == 0)
@@ -78,7 +78,7 @@ public sealed class SafeRequestHeadersLayoutRenderer : AspNetLayoutRendererBase
     }
 
     /// <summary>
-    /// Gets a reusable empty dictionary instance to avoid unnecessary allocations.
+    /// Obtiene una instancia reutilizable de diccionario vacío para evitar asignaciones innecesarias.
     /// </summary>
     private static IReadOnlyDictionary<string, string> EmptyHeaders { get; } =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);

--- a/Backend/ProyectoBase.Api/Logging/SafeUserClaimsLayoutRenderer.cs
+++ b/Backend/ProyectoBase.Api/Logging/SafeUserClaimsLayoutRenderer.cs
@@ -10,7 +10,7 @@ using NLog.Web.LayoutRenderers;
 namespace ProyectoBase.Api.Logging;
 
 /// <summary>
-/// Layout renderer that exposes authenticated user claims without leaking personal information.
+/// Representa un layout renderer que expone los claims del usuario autenticado sin revelar información personal.
 /// </summary>
 [LayoutRenderer("safe-user-claims")]
 public sealed class SafeUserClaimsLayoutRenderer : AspNetLayoutRendererBase
@@ -18,10 +18,10 @@ public sealed class SafeUserClaimsLayoutRenderer : AspNetLayoutRendererBase
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
     /// <summary>
-    /// Appends sanitized claim information to the provided string builder.
+    /// Agrega la información saneada de los claims al generador de cadenas proporcionado.
     /// </summary>
-    /// <param name="builder">The builder receiving the rendered output.</param>
-    /// <param name="logEvent">The log event being processed.</param>
+    /// <param name="builder">El generador que recibe la salida renderizada.</param>
+    /// <param name="logEvent">El evento de registro que se está procesando.</param>
     protected override void DoAppend(StringBuilder builder, LogEventInfo logEvent)
     {
         var claimsByType = GetClaimTypeCounts(HttpContextAccessor?.HttpContext);
@@ -34,10 +34,10 @@ public sealed class SafeUserClaimsLayoutRenderer : AspNetLayoutRendererBase
     }
 
     /// <summary>
-    /// Aggregates authenticated user claims by type masking their actual values.
+    /// Agrupa los claims del usuario autenticado por tipo enmascarando sus valores reales.
     /// </summary>
-    /// <param name="httpContext">The HTTP context supplying the claims.</param>
-    /// <returns>A dictionary containing claim type counts.</returns>
+    /// <param name="httpContext">El contexto HTTP que proporciona los claims.</param>
+    /// <returns>Un diccionario que contiene la cantidad de claims por tipo.</returns>
     internal static IReadOnlyDictionary<string, int> GetClaimTypeCounts(HttpContext? httpContext)
     {
         if (httpContext?.User?.Identity?.IsAuthenticated != true)
@@ -55,7 +55,7 @@ public sealed class SafeUserClaimsLayoutRenderer : AspNetLayoutRendererBase
     }
 
     /// <summary>
-    /// Gets a reusable empty dictionary instance to avoid unnecessary allocations.
+    /// Obtiene una instancia reutilizable de diccionario vacío para evitar asignaciones innecesarias.
     /// </summary>
     private static IReadOnlyDictionary<string, int> EmptyClaims { get; } =
         new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);

--- a/Backend/ProyectoBase.Api/Middlewares/ExceptionHandlingMiddleware.cs
+++ b/Backend/ProyectoBase.Api/Middlewares/ExceptionHandlingMiddleware.cs
@@ -3,14 +3,13 @@ using System.Text.Json;
 using System.Linq;
 using FluentValidation;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using ProyectoBase.Domain.Exceptions;
 
 namespace ProyectoBase.Api.Middlewares;
 
 /// <summary>
-/// Middleware responsible for translating unhandled exceptions into standardized HTTP responses.
+/// Middleware responsable de traducir las excepciones no controladas en respuestas HTTP estandarizadas.
 /// </summary>
 public sealed class ExceptionHandlingMiddleware
 {
@@ -20,10 +19,10 @@ public sealed class ExceptionHandlingMiddleware
     private readonly ILogger<ExceptionHandlingMiddleware> _logger;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ExceptionHandlingMiddleware"/> class.
+    /// Inicializa una nueva instancia de la clase <see cref="ExceptionHandlingMiddleware"/>.
     /// </summary>
-    /// <param name="next">The next middleware in the pipeline.</param>
-    /// <param name="logger">The logger used to emit diagnostic information.</param>
+    /// <param name="next">El siguiente middleware en la canalización.</param>
+    /// <param name="logger">El registrador utilizado para emitir información de diagnóstico.</param>
     public ExceptionHandlingMiddleware(RequestDelegate next, ILogger<ExceptionHandlingMiddleware> logger)
     {
         _next = next;
@@ -31,9 +30,9 @@ public sealed class ExceptionHandlingMiddleware
     }
 
     /// <summary>
-    /// Processes the current <see cref="HttpContext"/> instance.
+    /// Procesa la instancia actual de <see cref="HttpContext"/>.
     /// </summary>
-    /// <param name="context">The HTTP context.</param>
+    /// <param name="context">El contexto HTTP.</param>
     public async Task InvokeAsync(HttpContext context)
     {
         try
@@ -50,7 +49,7 @@ public sealed class ExceptionHandlingMiddleware
     {
         if (context.Response.HasStarted)
         {
-            _logger.LogError(exception, "The response has already started, the exception middleware cannot handle the error.");
+            _logger.LogError(exception, "La respuesta ya comenzó; el middleware de excepciones no puede gestionar el error.");
             throw;
         }
 
@@ -81,36 +80,36 @@ public sealed class ExceptionHandlingMiddleware
             NotFoundException notFound => new ExceptionMapping
             {
                 StatusCode = StatusCodes.Status404NotFound,
-                Error = ReasonPhrases.GetReasonPhrase(StatusCodes.Status404NotFound)!,
+                Error = "Recurso no encontrado",
                 Details = string.IsNullOrWhiteSpace(notFound.Message)
-                    ? "The requested resource was not found."
+                    ? "El recurso solicitado no fue encontrado."
                     : notFound.Message,
                 LogLevel = LogLevel.Warning,
-                LogMessage = "A not found error occurred while processing {Path}.",
+                LogMessage = "Se produjo un error de recurso no encontrado al procesar {Path}.",
             },
             Domain.Exceptions.ValidationException domainValidation => new ExceptionMapping
             {
                 StatusCode = StatusCodes.Status400BadRequest,
-                Error = ReasonPhrases.GetReasonPhrase(StatusCodes.Status400BadRequest)!,
+                Error = "Solicitud inválida",
                 Details = GetDomainValidationDetails(domainValidation),
                 LogLevel = LogLevel.Warning,
-                LogMessage = "A domain validation error occurred while processing {Path}.",
+                LogMessage = "Se produjo un error de validación de dominio al procesar {Path}.",
             },
             ValidationException fluentValidation => new ExceptionMapping
             {
                 StatusCode = StatusCodes.Status400BadRequest,
-                Error = ReasonPhrases.GetReasonPhrase(StatusCodes.Status400BadRequest)!,
+                Error = "Solicitud inválida",
                 Details = GetFluentValidationDetails(fluentValidation),
                 LogLevel = LogLevel.Warning,
-                LogMessage = "A validation error occurred while processing {Path}.",
+                LogMessage = "Se produjo un error de validación al procesar {Path}.",
             },
             _ => new ExceptionMapping
             {
                 StatusCode = StatusCodes.Status500InternalServerError,
-                Error = ReasonPhrases.GetReasonPhrase(StatusCodes.Status500InternalServerError)!,
-                Details = "An unexpected error occurred.",
+                Error = "Error interno del servidor",
+                Details = "Ocurrió un error inesperado.",
                 LogLevel = LogLevel.Error,
-                LogMessage = "An unexpected error occurred while processing {Path}.",
+                LogMessage = "Ocurrió un error inesperado al procesar {Path}.",
             },
         };
     }
@@ -118,7 +117,7 @@ public sealed class ExceptionHandlingMiddleware
     private static IReadOnlyCollection<string> GetDomainValidationDetails(Domain.Exceptions.ValidationException exception)
     {
         var message = string.IsNullOrWhiteSpace(exception.Message)
-            ? "The provided data is not valid."
+            ? "Los datos proporcionados no son válidos."
             : exception.Message;
 
         return new[] { message };

--- a/Backend/ProyectoBase.Api/Program.cs
+++ b/Backend/ProyectoBase.Api/Program.cs
@@ -68,7 +68,7 @@ builder.Services.AddSwaggerGen(options =>
         Scheme = "bearer",
         BearerFormat = "JWT",
         In = ParameterLocation.Header,
-        Description = "JWT Authorization header using the Bearer scheme.",
+        Description = "Encabezado de autorización JWT usando el esquema Bearer.",
     });
 
     options.AddSecurityRequirement(new OpenApiSecurityRequirement
@@ -109,7 +109,7 @@ var jwtSettings = builder.Configuration.GetSection(JwtOptions.SectionName).Get<J
 
 if (string.IsNullOrWhiteSpace(jwtSettings.Key))
 {
-    throw new InvalidOperationException("JWT signing key is not configured.");
+    throw new InvalidOperationException("La clave de firma JWT no está configurada.");
 }
 
 var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
@@ -133,7 +133,7 @@ builder.Services.AddCors(options =>
         {
             if (builder.Environment.IsProduction())
             {
-                throw new InvalidOperationException("Cors:AllowedOrigins configuration is required in production.");
+                throw new InvalidOperationException("La configuración Cors:AllowedOrigins es obligatoria en producción.");
             }
 
             policy.AllowAnyOrigin()

--- a/Backend/ProyectoBase.Api/Swagger/ConfigureSwaggerOptions.cs
+++ b/Backend/ProyectoBase.Api/Swagger/ConfigureSwaggerOptions.cs
@@ -6,16 +6,16 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 namespace ProyectoBase.Api.Swagger;
 
 /// <summary>
-/// Configures Swagger documents based on the available API versions.
+/// Configura los documentos de Swagger según las versiones disponibles de la API.
 /// </summary>
 public sealed class ConfigureSwaggerOptions : IConfigureOptions<SwaggerGenOptions>
 {
     private readonly IApiVersionDescriptionProvider _provider;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ConfigureSwaggerOptions"/> class.
+    /// Inicializa una nueva instancia de la clase <see cref="ConfigureSwaggerOptions"/>.
     /// </summary>
-    /// <param name="provider">The API version description provider.</param>
+    /// <param name="provider">El proveedor de descripciones de versiones de la API.</param>
     public ConfigureSwaggerOptions(IApiVersionDescriptionProvider provider)
     {
         _provider = provider;
@@ -35,14 +35,14 @@ public sealed class ConfigureSwaggerOptions : IConfigureOptions<SwaggerGenOption
     {
         var info = new OpenApiInfo
         {
-            Title = "ProyectoBase API",
+            Title = "API de ProyectoBase",
             Version = description.ApiVersion.ToString(),
-            Description = "API documentation for ProyectoBase.",
+            Description = "Documentación de la API de ProyectoBase.",
         };
 
         if (description.IsDeprecated)
         {
-            info.Description += " This API version has been deprecated.";
+            info.Description += " Esta versión de la API se encuentra obsoleta.";
         }
 
         return info;

--- a/Backend/ProyectoBase.Api/Swagger/ErrorResponse.cs
+++ b/Backend/ProyectoBase.Api/Swagger/ErrorResponse.cs
@@ -1,27 +1,27 @@
 namespace ProyectoBase.Api.Swagger;
 
 /// <summary>
-/// Represents the standardized error contract returned by the API.
+/// Representa el contrato de error estandarizado que devuelve la API.
 /// </summary>
 public sealed record ErrorResponse
 {
     /// <summary>
-    /// Gets the unique identifier associated with the request.
+    /// Obtiene el identificador único asociado a la solicitud.
     /// </summary>
     public required string TraceId { get; init; }
 
     /// <summary>
-    /// Gets the HTTP status code returned by the API.
+    /// Obtiene el código de estado HTTP devuelto por la API.
     /// </summary>
     public required int Status { get; init; }
 
     /// <summary>
-    /// Gets a short description of the error.
+    /// Obtiene una descripción breve del error.
     /// </summary>
     public required string Error { get; init; }
 
     /// <summary>
-    /// Gets additional error details when available.
+    /// Obtiene detalles adicionales del error cuando están disponibles.
     /// </summary>
     public object? Details { get; init; }
 }

--- a/Backend/ProyectoBase.Api/Swagger/Filters/DefaultResponsesOperationFilter.cs
+++ b/Backend/ProyectoBase.Api/Swagger/Filters/DefaultResponsesOperationFilter.cs
@@ -8,7 +8,7 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 namespace ProyectoBase.Api.Swagger.Filters;
 
 /// <summary>
-/// Ensures that default error responses are documented for all operations.
+/// Garantiza que las respuestas de error predeterminadas queden documentadas para todas las operaciones.
 /// </summary>
 public sealed class DefaultResponsesOperationFilter : IOperationFilter
 {
@@ -25,9 +25,9 @@ public sealed class DefaultResponsesOperationFilter : IOperationFilter
             throw new ArgumentNullException(nameof(context));
         }
 
-        AddResponse(operation, context, StatusCodes.Status400BadRequest, "Bad request.");
-        AddResponse(operation, context, StatusCodes.Status404NotFound, "Resource not found.");
-        AddResponse(operation, context, StatusCodes.Status500InternalServerError, "Unexpected error.");
+        AddResponse(operation, context, StatusCodes.Status400BadRequest, "Solicitud inválida.");
+        AddResponse(operation, context, StatusCodes.Status404NotFound, "Recurso no encontrado.");
+        AddResponse(operation, context, StatusCodes.Status500InternalServerError, "Error inesperado.");
     }
 
     private static void AddResponse(OpenApiOperation operation, OperationFilterContext context, int statusCode, string description)

--- a/Backend/ProyectoBase.Api/Swagger/SwaggerGenOptionsExtensions.cs
+++ b/Backend/ProyectoBase.Api/Swagger/SwaggerGenOptionsExtensions.cs
@@ -10,15 +10,15 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 namespace ProyectoBase.Api.Swagger;
 
 /// <summary>
-/// Provides helper methods to configure Swagger generation.
+/// Proporciona métodos auxiliares para configurar la generación de Swagger.
 /// </summary>
 public static class SwaggerGenOptionsExtensions
 {
     /// <summary>
-    /// Maps enumeration values to the <c>code</c> representation defined by <see cref="EnumMemberAttribute"/>.
+    /// Mapea los valores de las enumeraciones a la representación <c>code</c> definida por <see cref="EnumMemberAttribute"/>.
     /// </summary>
-    /// <param name="options">The Swagger generation options.</param>
-    /// <param name="assemblies">Assemblies that may contain enums to map.</param>
+    /// <param name="options">Las opciones de generación de Swagger.</param>
+    /// <param name="assemblies">Los ensamblados que pueden contener enumeraciones a mapear.</param>
     public static void MapCodeEnumsFromAssemblies(this SwaggerGenOptions options, params Assembly[] assemblies)
     {
         if (options == null)
@@ -56,7 +56,7 @@ public static class SwaggerGenOptionsExtensions
         {
             Type = "string",
             Enum = values,
-            Description = $"Enumeration of {enumType.Name} values.",
+            Description = $"Enumeración de valores de {enumType.Name}.",
         };
     }
 

--- a/Backend/ProyectoBase.Application/Abstractions/IProductRepository.cs
+++ b/Backend/ProyectoBase.Application/Abstractions/IProductRepository.cs
@@ -7,47 +7,47 @@ using ProyectoBase.Domain.Entities;
 namespace ProyectoBase.Application.Abstractions
 {
     /// <summary>
-    /// Provides data access operations for <see cref="Product"/> entities.
+    /// Proporciona operaciones de acceso a datos para entidades <see cref="Product"/>.
     /// </summary>
     public interface IProductRepository
     {
         /// <summary>
-        /// Retrieves a product by its unique identifier.
+        /// Recupera un producto por su identificador único.
         /// </summary>
-        /// <param name="id">The identifier of the product to retrieve.</param>
-        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-        /// <returns>The matching <see cref="Product"/> instance, if it exists.</returns>
+        /// <param name="id">El identificador del producto que se desea obtener.</param>
+        /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+        /// <returns>La instancia de <see cref="Product"/> correspondiente, si existe.</returns>
         Task<Product?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Retrieves all products available in the data store.
+        /// Recupera todos los productos disponibles en el almacén de datos.
         /// </summary>
-        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-        /// <returns>A read-only collection containing the available products.</returns>
+        /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+        /// <returns>Una colección de solo lectura con los productos disponibles.</returns>
         Task<IReadOnlyCollection<Product>> GetAllAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Persists a new product in the data store.
+        /// Persiste un nuevo producto en el almacén de datos.
         /// </summary>
-        /// <param name="product">The product to persist.</param>
-        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-        /// <returns>A task that represents the asynchronous operation.</returns>
+        /// <param name="product">El producto que se desea guardar.</param>
+        /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+        /// <returns>Una tarea que representa la operación asincrónica.</returns>
         Task AddAsync(Product product, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Updates an existing product in the data store.
+        /// Actualiza un producto existente en el almacén de datos.
         /// </summary>
-        /// <param name="product">The product instance containing the updates.</param>
-        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-        /// <returns>A task that represents the asynchronous operation.</returns>
+        /// <param name="product">La instancia del producto que contiene los cambios.</param>
+        /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+        /// <returns>Una tarea que representa la operación asincrónica.</returns>
         Task UpdateAsync(Product product, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Removes a product from the data store.
+        /// Elimina un producto del almacén de datos.
         /// </summary>
-        /// <param name="id">The identifier of the product to delete.</param>
-        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-        /// <returns>A task that represents the asynchronous operation.</returns>
+        /// <param name="id">El identificador del producto que se desea eliminar.</param>
+        /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+        /// <returns>Una tarea que representa la operación asincrónica.</returns>
         Task DeleteAsync(Guid id, CancellationToken cancellationToken = default);
     }
 }

--- a/Backend/ProyectoBase.Application/Abstractions/IProductService.cs
+++ b/Backend/ProyectoBase.Application/Abstractions/IProductService.cs
@@ -7,47 +7,47 @@ using ProyectoBase.Application.DTOs;
 namespace ProyectoBase.Application.Abstractions
 {
     /// <summary>
-    /// Defines the operations available to manage products within the application layer.
+    /// Define las operaciones disponibles para administrar productos dentro de la capa de aplicación.
     /// </summary>
     public interface IProductService
     {
         /// <summary>
-        /// Creates a new product from the provided information.
+        /// Crea un nuevo producto a partir de la información proporcionada.
         /// </summary>
-        /// <param name="product">The data describing the product to create.</param>
-        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-        /// <returns>The representation of the created product.</returns>
+        /// <param name="product">Los datos que describen el producto a crear.</param>
+        /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+        /// <returns>La representación del producto creado.</returns>
         Task<ProductResponseDto> CreateAsync(ProductCreateDto product, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Updates an existing product using the supplied information.
+        /// Actualiza un producto existente utilizando la información suministrada.
         /// </summary>
-        /// <param name="product">The data describing the product to update.</param>
-        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-        /// <returns>The representation of the updated product.</returns>
+        /// <param name="product">Los datos que describen el producto a actualizar.</param>
+        /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+        /// <returns>La representación del producto actualizado.</returns>
         Task<ProductResponseDto> UpdateAsync(ProductUpdateDto product, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Retrieves a product by its unique identifier.
+        /// Recupera un producto por su identificador único.
         /// </summary>
-        /// <param name="id">The identifier of the product to retrieve.</param>
-        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-        /// <returns>The requested product representation, if it exists.</returns>
+        /// <param name="id">El identificador del producto que se desea obtener.</param>
+        /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+        /// <returns>La representación del producto solicitado, si existe.</returns>
         Task<ProductResponseDto?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Retrieves all products available in the application context.
+        /// Recupera todos los productos disponibles en el contexto de la aplicación.
         /// </summary>
-        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-        /// <returns>A collection containing the available product representations.</returns>
+        /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+        /// <returns>Una colección que contiene las representaciones de los productos disponibles.</returns>
         Task<IReadOnlyCollection<ProductResponseDto>> GetAllAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Removes the product that matches the provided identifier.
+        /// Elimina el producto que coincide con el identificador proporcionado.
         /// </summary>
-        /// <param name="id">The identifier of the product to remove.</param>
-        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-        /// <returns>A task representing the asynchronous operation.</returns>
+        /// <param name="id">El identificador del producto que se eliminará.</param>
+        /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+        /// <returns>Una tarea que representa la operación asincrónica.</returns>
         Task DeleteAsync(Guid id, CancellationToken cancellationToken = default);
     }
 }

--- a/Backend/ProyectoBase.Application/Abstractions/ITokenService.cs
+++ b/Backend/ProyectoBase.Application/Abstractions/ITokenService.cs
@@ -4,14 +4,14 @@ using System.Security.Claims;
 namespace ProyectoBase.Application.Abstractions;
 
 /// <summary>
-/// Provides functionality to create JSON Web Tokens for authenticated users.
+/// Proporciona funcionalidad para crear tokens JSON Web para usuarios autenticados.
 /// </summary>
 public interface ITokenService
 {
     /// <summary>
-    /// Generates a signed JWT access token using the provided claims.
+    /// Genera un token de acceso JWT firmado utilizando los claims proporcionados.
     /// </summary>
-    /// <param name="claims">The claims to embed in the token.</param>
-    /// <returns>The serialized JWT token.</returns>
+    /// <param name="claims">Los claims que se incluirán en el token.</param>
+    /// <returns>El token JWT serializado.</returns>
     string GenerateAccessToken(IEnumerable<Claim> claims);
 }

--- a/Backend/ProyectoBase.Application/DTOs/ProductCreateDto.cs
+++ b/Backend/ProyectoBase.Application/DTOs/ProductCreateDto.cs
@@ -3,33 +3,33 @@ using System.ComponentModel.DataAnnotations;
 namespace ProyectoBase.Application.DTOs
 {
     /// <summary>
-    /// Represents the data required to create a new product.
+    /// Representa los datos necesarios para crear un nuevo producto.
     /// </summary>
     public class ProductCreateDto
     {
         /// <summary>
-        /// Gets or sets the name of the product.
+        /// Obtiene o establece el nombre del producto.
         /// </summary>
-        [Required]
-        [StringLength(100, MinimumLength = 2)]
+        [Required(ErrorMessage = "El nombre del producto es obligatorio.")]
+        [StringLength(100, MinimumLength = 2, ErrorMessage = "El nombre debe tener entre 2 y 100 caracteres.")]
         public string Name { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets or sets the description of the product.
+        /// Obtiene o establece la descripción del producto.
         /// </summary>
-        [StringLength(500)]
+        [StringLength(500, ErrorMessage = "La descripción no puede superar los 500 caracteres.")]
         public string? Description { get; set; }
 
         /// <summary>
-        /// Gets or sets the price of the product.
+        /// Obtiene o establece el precio del producto.
         /// </summary>
-        [Range(0.01, 999999.99)]
+        [Range(0.01, 999999.99, ErrorMessage = "El precio debe estar entre 0,01 y 999.999,99.")]
         public decimal Price { get; set; }
 
         /// <summary>
-        /// Gets or sets the available stock of the product.
+        /// Obtiene o establece el inventario disponible del producto.
         /// </summary>
-        [Range(0, int.MaxValue)]
+        [Range(0, int.MaxValue, ErrorMessage = "El inventario debe ser un número mayor o igual que cero.")]
         public int Stock { get; set; }
     }
 }

--- a/Backend/ProyectoBase.Application/DTOs/ProductResponseDto.cs
+++ b/Backend/ProyectoBase.Application/DTOs/ProductResponseDto.cs
@@ -3,32 +3,32 @@ using System;
 namespace ProyectoBase.Application.DTOs
 {
     /// <summary>
-    /// Represents the product data returned by application services.
+    /// Representa los datos de producto devueltos por los servicios de la aplicación.
     /// </summary>
     public class ProductResponseDto
     {
         /// <summary>
-        /// Gets or sets the unique identifier of the product.
+        /// Obtiene o establece el identificador único del producto.
         /// </summary>
         public Guid Id { get; set; }
 
         /// <summary>
-        /// Gets or sets the name of the product.
+        /// Obtiene o establece el nombre del producto.
         /// </summary>
         public string Name { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets or sets the optional description of the product.
+        /// Obtiene o establece la descripción opcional del producto.
         /// </summary>
         public string? Description { get; set; }
 
         /// <summary>
-        /// Gets or sets the price of the product.
+        /// Obtiene o establece el precio del producto.
         /// </summary>
         public decimal Price { get; set; }
 
         /// <summary>
-        /// Gets or sets the available stock of the product.
+        /// Obtiene o establece el inventario disponible del producto.
         /// </summary>
         public int Stock { get; set; }
     }

--- a/Backend/ProyectoBase.Application/DTOs/ProductUpdateDto.cs
+++ b/Backend/ProyectoBase.Application/DTOs/ProductUpdateDto.cs
@@ -4,14 +4,14 @@ using System.ComponentModel.DataAnnotations;
 namespace ProyectoBase.Application.DTOs
 {
     /// <summary>
-    /// Represents the information required to update an existing product.
+    /// Representa la información necesaria para actualizar un producto existente.
     /// </summary>
     public class ProductUpdateDto : ProductCreateDto
     {
         /// <summary>
-        /// Gets or sets the unique identifier of the product to update.
+        /// Obtiene o establece el identificador único del producto que se desea actualizar.
         /// </summary>
-        [Required]
+        [Required(ErrorMessage = "El identificador del producto es obligatorio.")]
         public Guid Id { get; set; }
     }
 }

--- a/Backend/ProyectoBase.Application/DependencyInjection.cs
+++ b/Backend/ProyectoBase.Application/DependencyInjection.cs
@@ -9,15 +9,15 @@ using ProyectoBase.Application.Services.Products;
 namespace ProyectoBase.Application;
 
 /// <summary>
-/// Provides extension methods to register application layer services within the dependency injection container.
+/// Proporciona métodos de extensión para registrar los servicios de la capa de aplicación en el contenedor de dependencias.
 /// </summary>
 public static class DependencyInjection
 {
     /// <summary>
-    /// Registers the application layer dependencies including services, validators and AutoMapper profiles.
+    /// Registra las dependencias de la capa de aplicación, incluidos servicios, validadores y perfiles de AutoMapper.
     /// </summary>
-    /// <param name="services">The service collection to configure.</param>
-    /// <returns>The configured <see cref="IServiceCollection"/> instance.</returns>
+    /// <param name="services">La colección de servicios que se configurará.</param>
+    /// <returns>La instancia configurada de <see cref="IServiceCollection"/>.</returns>
     public static IServiceCollection AddApplication(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);

--- a/Backend/ProyectoBase.Application/Mappings/ProductProfile.cs
+++ b/Backend/ProyectoBase.Application/Mappings/ProductProfile.cs
@@ -6,12 +6,12 @@ using ProyectoBase.Domain.Entities;
 namespace ProyectoBase.Application.Mappings;
 
 /// <summary>
-/// Defines the mappings between product domain entities and DTOs.
+/// Define los mapeos entre las entidades de dominio de productos y sus DTO.
 /// </summary>
 public class ProductProfile : Profile
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ProductProfile"/> class.
+    /// Inicializa una nueva instancia de la clase <see cref="ProductProfile"/>.
     /// </summary>
     public ProductProfile()
     {

--- a/Backend/ProyectoBase.Application/Options/JwtOptions.cs
+++ b/Backend/ProyectoBase.Application/Options/JwtOptions.cs
@@ -1,37 +1,37 @@
 namespace ProyectoBase.Application.Options;
 
 /// <summary>
-/// Represents configuration settings for JWT token generation and validation.
+/// Representa la configuración necesaria para generar y validar tokens JWT.
 /// </summary>
 public class JwtOptions
 {
     /// <summary>
-    /// The configuration section name for JWT settings.
+    /// Nombre de la sección de configuración que contiene los valores de JWT.
     /// </summary>
     public const string SectionName = "Jwt";
 
     /// <summary>
-    /// Gets or sets the token issuer.
+    /// Obtiene o establece el emisor del token.
     /// </summary>
     public string Issuer { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the expected token audience.
+    /// Obtiene o establece la audiencia esperada del token.
     /// </summary>
     public string Audience { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the symmetric signing key used to sign tokens.
+    /// Obtiene o establece la clave simétrica utilizada para firmar los tokens.
     /// </summary>
     public string Key { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the access token expiration time in minutes.
+    /// Obtiene o establece el tiempo de expiración del token de acceso en minutos.
     /// </summary>
     public int AccessTokenExpirationMinutes { get; set; } = 60;
 
     /// <summary>
-    /// Gets or sets the refresh token expiration time in days.
+    /// Obtiene o establece el tiempo de expiración del token de actualización en días.
     /// </summary>
     public int RefreshTokenExpirationDays { get; set; } = 7;
 }

--- a/Backend/ProyectoBase.Application/Services/Products/CreateProductCommand.cs
+++ b/Backend/ProyectoBase.Application/Services/Products/CreateProductCommand.cs
@@ -4,21 +4,21 @@ using ProyectoBase.Application.DTOs;
 namespace ProyectoBase.Application.Services.Products
 {
     /// <summary>
-    /// Command used to request the creation of a new product.
+    /// Comando utilizado para solicitar la creación de un nuevo producto.
     /// </summary>
     public class CreateProductCommand : IRequest<ProductResponseDto>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="CreateProductCommand"/> class.
+        /// Inicializa una nueva instancia de la clase <see cref="CreateProductCommand"/>.
         /// </summary>
-        /// <param name="product">The product data associated with the command.</param>
+        /// <param name="product">La información del producto asociada al comando.</param>
         public CreateProductCommand(ProductCreateDto product)
         {
             Product = product;
         }
 
         /// <summary>
-        /// Gets the product data provided with the command.
+        /// Obtiene la información del producto proporcionada en el comando.
         /// </summary>
         public ProductCreateDto Product { get; }
     }

--- a/Backend/ProyectoBase.Application/Services/Products/CreateProductCommandHandler.cs
+++ b/Backend/ProyectoBase.Application/Services/Products/CreateProductCommandHandler.cs
@@ -7,16 +7,16 @@ using ProyectoBase.Application.DTOs;
 namespace ProyectoBase.Application.Services.Products
 {
     /// <summary>
-    /// Handles <see cref="CreateProductCommand"/> requests by delegating to the product service.
+    /// Atiende solicitudes de <see cref="CreateProductCommand"/> delegando en el servicio de productos.
     /// </summary>
     public class CreateProductCommandHandler : IRequestHandler<CreateProductCommand, ProductResponseDto>
     {
         private readonly IProductService _productService;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CreateProductCommandHandler"/> class.
+        /// Inicializa una nueva instancia de la clase <see cref="CreateProductCommandHandler"/>.
         /// </summary>
-        /// <param name="productService">The product service used to perform the operation.</param>
+        /// <param name="productService">El servicio de productos que ejecuta la operación.</param>
         public CreateProductCommandHandler(IProductService productService)
         {
             _productService = productService;

--- a/Backend/ProyectoBase.Application/Services/Products/ProductService.cs
+++ b/Backend/ProyectoBase.Application/Services/Products/ProductService.cs
@@ -13,7 +13,7 @@ using ProyectoBase.Domain.Exceptions;
 namespace ProyectoBase.Application.Services.Products;
 
 /// <summary>
-/// Provides application level operations to manage products.
+/// Proporciona operaciones de nivel de aplicación para administrar productos.
 /// </summary>
 public class ProductService : IProductService
 {
@@ -26,11 +26,11 @@ public class ProductService : IProductService
     private readonly IDistributedCache _cache;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ProductService"/> class.
+    /// Inicializa una nueva instancia de la clase <see cref="ProductService"/>.
     /// </summary>
-    /// <param name="productRepository">The repository used to persist products.</param>
-    /// <param name="mapper">The mapper used to project entities into DTOs.</param>
-    /// <param name="cache">The distributed cache used to store product collections.</param>
+    /// <param name="productRepository">El repositorio utilizado para persistir productos.</param>
+    /// <param name="mapper">El mapeador utilizado para proyectar entidades en DTO.</param>
+    /// <param name="cache">La caché distribuida donde se almacenan las colecciones de productos.</param>
     public ProductService(IProductRepository productRepository, IMapper mapper, IDistributedCache cache)
     {
         _productRepository = productRepository ?? throw new ArgumentNullException(nameof(productRepository));
@@ -60,7 +60,7 @@ public class ProductService : IProductService
 
         if (entity is null)
         {
-            throw new NotFoundException($"The product with id '{product.Id}' was not found.");
+            throw new NotFoundException($"No se encontró el producto con identificador '{product.Id}'.");
         }
 
         _mapper.Map(product, entity);

--- a/Backend/ProyectoBase.Application/Validators/CreateProductDtoValidator.cs
+++ b/Backend/ProyectoBase.Application/Validators/CreateProductDtoValidator.cs
@@ -4,28 +4,28 @@ using ProyectoBase.Application.DTOs;
 namespace ProyectoBase.Application.Validators
 {
     /// <summary>
-    /// Ensures <see cref="ProductCreateDto"/> instances contain valid data before being processed.
+    /// Garantiza que las instancias de <see cref="ProductCreateDto"/> contengan datos válidos antes de ser procesadas.
     /// </summary>
     public class CreateProductDtoValidator : AbstractValidator<ProductCreateDto>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="CreateProductDtoValidator"/> class.
+        /// Inicializa una nueva instancia de la clase <see cref="CreateProductDtoValidator"/>.
         /// </summary>
         public CreateProductDtoValidator()
         {
             RuleFor(product => product.Name)
-                .NotEmpty()
-                .Length(2, 100);
+                .NotEmpty().WithMessage("El nombre del producto es obligatorio.")
+                .Length(2, 100).WithMessage("El nombre debe tener entre 2 y 100 caracteres.");
 
             RuleFor(product => product.Description)
-                .MaximumLength(500);
+                .MaximumLength(500).WithMessage("La descripción no puede superar los 500 caracteres.");
 
             RuleFor(product => product.Price)
-                .GreaterThan(0)
-                .LessThanOrEqualTo(999999.99m);
+                .GreaterThan(0).WithMessage("El precio debe ser mayor que cero.")
+                .LessThanOrEqualTo(999999.99m).WithMessage("El precio no puede superar 999.999,99.");
 
             RuleFor(product => product.Stock)
-                .GreaterThanOrEqualTo(0);
+                .GreaterThanOrEqualTo(0).WithMessage("El inventario debe ser un número mayor o igual que cero.");
         }
     }
 }

--- a/Backend/ProyectoBase.Application/Validators/UpdateProductDtoValidator.cs
+++ b/Backend/ProyectoBase.Application/Validators/UpdateProductDtoValidator.cs
@@ -4,19 +4,19 @@ using ProyectoBase.Application.DTOs;
 namespace ProyectoBase.Application.Validators
 {
     /// <summary>
-    /// Ensures <see cref="ProductUpdateDto"/> instances contain valid data before being processed.
+    /// Garantiza que las instancias de <see cref="ProductUpdateDto"/> contengan datos válidos antes de ser procesadas.
     /// </summary>
     public class UpdateProductDtoValidator : AbstractValidator<ProductUpdateDto>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="UpdateProductDtoValidator"/> class.
+        /// Inicializa una nueva instancia de la clase <see cref="UpdateProductDtoValidator"/>.
         /// </summary>
         public UpdateProductDtoValidator()
         {
             Include(new CreateProductDtoValidator());
 
             RuleFor(product => product.Id)
-                .NotEmpty();
+                .NotEmpty().WithMessage("El identificador del producto es obligatorio.");
         }
     }
 }

--- a/Backend/ProyectoBase.Domain/Entities/Product.cs
+++ b/Backend/ProyectoBase.Domain/Entities/Product.cs
@@ -4,23 +4,23 @@ using ProyectoBase.Domain.Exceptions;
 namespace ProyectoBase.Domain.Entities
 {
     /// <summary>
-    /// Represents a product available for sale.
+    /// Representa un producto disponible para la venta.
     /// </summary>
     public class Product
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Product"/> class.
+        /// Inicializa una nueva instancia de la clase <see cref="Product"/>.
         /// </summary>
-        /// <param name="id">The unique identifier of the product.</param>
-        /// <param name="name">The name of the product.</param>
-        /// <param name="price">The unit price of the product.</param>
-        /// <param name="stock">The quantity available in stock.</param>
-        /// <param name="description">The optional description of the product.</param>
+        /// <param name="id">El identificador único del producto.</param>
+        /// <param name="name">El nombre del producto.</param>
+        /// <param name="price">El precio unitario del producto.</param>
+        /// <param name="stock">La cantidad disponible en inventario.</param>
+        /// <param name="description">La descripción opcional del producto.</param>
         public Product(Guid id, string name, decimal price, int stock, string? description = null)
         {
             if (id == Guid.Empty)
             {
-                throw new ValidationException("The product identifier must be provided.");
+                throw new ValidationException("Se debe proporcionar el identificador del producto.");
             }
 
             Id = id;
@@ -31,95 +31,95 @@ namespace ProyectoBase.Domain.Entities
         }
 
         /// <summary>
-        /// Gets the unique identifier of the product.
+        /// Obtiene el identificador único del producto.
         /// </summary>
         public Guid Id { get; }
 
         /// <summary>
-        /// Gets the name of the product.
+        /// Obtiene el nombre del producto.
         /// </summary>
         public string Name { get; private set; } = string.Empty;
 
         /// <summary>
-        /// Gets the optional description of the product.
+        /// Obtiene la descripción opcional del producto.
         /// </summary>
         public string? Description { get; private set; }
 
         /// <summary>
-        /// Gets the current price of the product.
+        /// Obtiene el precio vigente del producto.
         /// </summary>
         public decimal Price { get; private set; }
 
         /// <summary>
-        /// Gets the available stock quantity of the product.
+        /// Obtiene la cantidad disponible en inventario del producto.
         /// </summary>
         public int Stock { get; private set; }
 
         /// <summary>
-        /// Updates the name of the product.
+        /// Actualiza el nombre del producto.
         /// </summary>
-        /// <param name="name">The new name of the product.</param>
+        /// <param name="name">El nuevo nombre del producto.</param>
         public void UpdateName(string name)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
-                throw new ValidationException("The product name cannot be empty.");
+                throw new ValidationException("El nombre del producto no puede estar vacío.");
             }
 
             Name = name.Trim();
         }
 
         /// <summary>
-        /// Updates the description of the product.
+        /// Actualiza la descripción del producto.
         /// </summary>
-        /// <param name="description">The new description of the product.</param>
+        /// <param name="description">La nueva descripción del producto.</param>
         public void UpdateDescription(string? description)
         {
             Description = string.IsNullOrWhiteSpace(description) ? null : description.Trim();
         }
 
         /// <summary>
-        /// Changes the price of the product.
+        /// Cambia el precio del producto.
         /// </summary>
-        /// <param name="price">The new price to assign.</param>
+        /// <param name="price">El nuevo precio a asignar.</param>
         public void ChangePrice(decimal price)
         {
             if (price < 0)
             {
-                throw new ValidationException("The product price cannot be negative.");
+                throw new ValidationException("El precio del producto no puede ser negativo.");
             }
 
             Price = decimal.Round(price, 2, MidpointRounding.AwayFromZero);
         }
 
         /// <summary>
-        /// Increases the stock quantity by the specified amount.
+        /// Incrementa la cantidad en inventario en la medida indicada.
         /// </summary>
-        /// <param name="quantity">The quantity to add to the stock.</param>
+        /// <param name="quantity">La cantidad que se agregará al inventario.</param>
         public void IncreaseStock(int quantity)
         {
             if (quantity <= 0)
             {
-                throw new ValidationException("The quantity to increase must be greater than zero.");
+                throw new ValidationException("La cantidad a incrementar debe ser mayor que cero.");
             }
 
             Stock += quantity;
         }
 
         /// <summary>
-        /// Decreases the stock quantity by the specified amount.
+        /// Disminuye la cantidad en inventario en la medida indicada.
         /// </summary>
-        /// <param name="quantity">The quantity to remove from the stock.</param>
+        /// <param name="quantity">La cantidad que se retirará del inventario.</param>
         public void DecreaseStock(int quantity)
         {
             if (quantity <= 0)
             {
-                throw new ValidationException("The quantity to decrease must be greater than zero.");
+                throw new ValidationException("La cantidad a disminuir debe ser mayor que cero.");
             }
 
             if (quantity > Stock)
             {
-                throw new ValidationException("The quantity to decrease exceeds the available stock.");
+                throw new ValidationException("La cantidad a disminuir excede el inventario disponible.");
             }
 
             Stock -= quantity;
@@ -129,7 +129,7 @@ namespace ProyectoBase.Domain.Entities
         {
             if (stock < 0)
             {
-                throw new ValidationException("The product stock cannot be negative.");
+                throw new ValidationException("El inventario del producto no puede ser negativo.");
             }
 
             Stock = stock;

--- a/Backend/ProyectoBase.Domain/Exceptions/DomainException.cs
+++ b/Backend/ProyectoBase.Domain/Exceptions/DomainException.cs
@@ -3,24 +3,24 @@ using System;
 namespace ProyectoBase.Domain.Exceptions
 {
     /// <summary>
-    /// Represents errors that occur within the domain layer.
+    /// Representa errores que ocurren dentro de la capa de dominio.
     /// </summary>
     public class DomainException : Exception
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="DomainException"/> class with a specified error message.
+        /// Inicializa una nueva instancia de la clase <see cref="DomainException"/> con un mensaje de error específico.
         /// </summary>
-        /// <param name="message">The message that describes the error.</param>
+        /// <param name="message">El mensaje que describe el error.</param>
         public DomainException(string message)
             : base(message)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DomainException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// Inicializa una nueva instancia de la clase <see cref="DomainException"/> con un mensaje de error específico y una referencia a la excepción interna que causó esta excepción.
         /// </summary>
-        /// <param name="message">The message that describes the error.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception.</param>
+        /// <param name="message">El mensaje que describe el error.</param>
+        /// <param name="innerException">La excepción que provocó la excepción actual.</param>
         public DomainException(string message, Exception innerException)
             : base(message, innerException)
         {

--- a/Backend/ProyectoBase.Domain/Exceptions/NotFoundException.cs
+++ b/Backend/ProyectoBase.Domain/Exceptions/NotFoundException.cs
@@ -1,14 +1,14 @@
 namespace ProyectoBase.Domain.Exceptions
 {
     /// <summary>
-    /// Represents errors that occur when a requested resource cannot be found in the domain.
+    /// Representa errores que ocurren cuando no se encuentra un recurso solicitado en el dominio.
     /// </summary>
     public class NotFoundException : DomainException
     {
-        private const string DefaultMessage = "The requested resource was not found.";
+        private const string DefaultMessage = "El recurso solicitado no fue encontrado.";
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NotFoundException"/> class.
+        /// Inicializa una nueva instancia de la clase <see cref="NotFoundException"/>.
         /// </summary>
         public NotFoundException()
             : base(DefaultMessage)
@@ -16,9 +16,9 @@ namespace ProyectoBase.Domain.Exceptions
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NotFoundException"/> class with a specified error message.
+        /// Inicializa una nueva instancia de la clase <see cref="NotFoundException"/> con un mensaje de error específico.
         /// </summary>
-        /// <param name="message">The message that describes the error.</param>
+        /// <param name="message">El mensaje que describe el error.</param>
         public NotFoundException(string message)
             : base(message)
         {

--- a/Backend/ProyectoBase.Domain/Exceptions/ValidationException.cs
+++ b/Backend/ProyectoBase.Domain/Exceptions/ValidationException.cs
@@ -1,14 +1,14 @@
 namespace ProyectoBase.Domain.Exceptions
 {
     /// <summary>
-    /// Represents errors that occur when the domain detects invalid data.
+    /// Representa errores que ocurren cuando el dominio detecta datos no válidos.
     /// </summary>
     public class ValidationException : DomainException
     {
-        private const string DefaultMessage = "The provided data is not valid.";
+        private const string DefaultMessage = "Los datos proporcionados no son válidos.";
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ValidationException"/> class.
+        /// Inicializa una nueva instancia de la clase <see cref="ValidationException"/>.
         /// </summary>
         public ValidationException()
             : base(DefaultMessage)
@@ -16,9 +16,9 @@ namespace ProyectoBase.Domain.Exceptions
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ValidationException"/> class with a specified error message.
+        /// Inicializa una nueva instancia de la clase <see cref="ValidationException"/> con un mensaje de error específico.
         /// </summary>
-        /// <param name="message">The message that describes the error.</param>
+        /// <param name="message">El mensaje que describe el error.</param>
         public ValidationException(string message)
             : base(message)
         {

--- a/Backend/ProyectoBase.Domain/Repositories/IProductReadRepository.cs
+++ b/Backend/ProyectoBase.Domain/Repositories/IProductReadRepository.cs
@@ -6,16 +6,16 @@ using ProyectoBase.Domain.Entities;
 namespace ProyectoBase.Domain.Repositories
 {
     /// <summary>
-    /// Provides read-only access to <see cref="Product"/> entities from a persistence store.
+    /// Proporciona acceso de solo lectura a entidades <see cref="Product"/> desde un almacén de persistencia.
     /// </summary>
     public interface IProductReadRepository
     {
         /// <summary>
-        /// Retrieves a product by its unique identifier.
+        /// Recupera un producto por su identificador único.
         /// </summary>
-        /// <param name="id">The identifier of the product to retrieve.</param>
-        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-        /// <returns>The product that matches the provided identifier, or <c>null</c> if it does not exist.</returns>
+        /// <param name="id">El identificador del producto que se desea obtener.</param>
+        /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+        /// <returns>El producto que coincide con el identificador proporcionado o <c>null</c> si no existe.</returns>
         Task<Product?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
     }
 }

--- a/Backend/ProyectoBase.Domain/Services/ProductStockService.cs
+++ b/Backend/ProyectoBase.Domain/Services/ProductStockService.cs
@@ -8,16 +8,16 @@ using ProyectoBase.Domain.Repositories;
 namespace ProyectoBase.Domain.Services
 {
     /// <summary>
-    /// Provides domain operations related to product stock availability.
+    /// Proporciona operaciones de dominio relacionadas con la disponibilidad de inventario de productos.
     /// </summary>
     public class ProductStockService
     {
         private readonly IProductReadRepository _productRepository;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ProductStockService"/> class.
+        /// Inicializa una nueva instancia de la clase <see cref="ProductStockService"/>.
         /// </summary>
-        /// <param name="productRepository">The repository used to query products.</param>
+        /// <param name="productRepository">El repositorio utilizado para consultar productos.</param>
         public ProductStockService(IProductReadRepository productRepository)
         {
             ArgumentNullException.ThrowIfNull(productRepository);
@@ -26,26 +26,26 @@ namespace ProyectoBase.Domain.Services
         }
 
         /// <summary>
-        /// Determines whether a product has enough stock to satisfy the requested quantity.
+        /// Determina si un producto cuenta con inventario suficiente para cubrir la cantidad solicitada.
         /// </summary>
-        /// <param name="productId">The identifier of the product to evaluate.</param>
-        /// <param name="quantity">The quantity to verify.</param>
-        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-        /// <returns><c>true</c> when the requested quantity is available; otherwise, <c>false</c>.</returns>
-        /// <exception cref="NotFoundException">Thrown when the product cannot be found.</exception>
-        /// <exception cref="ValidationException">Thrown when the requested quantity is not greater than zero.</exception>
+        /// <param name="productId">El identificador del producto a evaluar.</param>
+        /// <param name="quantity">La cantidad que se desea verificar.</param>
+        /// <param name="cancellationToken">Token para cancelar la operación asincrónica.</param>
+        /// <returns><c>true</c> cuando la cantidad solicitada está disponible; de lo contrario, <c>false</c>.</returns>
+        /// <exception cref="NotFoundException">Se produce cuando no se encuentra el producto.</exception>
+        /// <exception cref="ValidationException">Se produce cuando la cantidad solicitada no es mayor que cero.</exception>
         public async Task<bool> IsStockAvailableAsync(Guid productId, int quantity, CancellationToken cancellationToken)
         {
             if (quantity <= 0)
             {
-                throw new ValidationException("The quantity to check must be greater than zero.");
+                throw new ValidationException("La cantidad a verificar debe ser mayor que cero.");
             }
 
             var product = await _productRepository.GetByIdAsync(productId, cancellationToken).ConfigureAwait(false);
 
             if (product is null)
             {
-                throw new NotFoundException($"The product '{productId}' was not found.");
+                throw new NotFoundException($"No se encontró el producto '{productId}'.");
             }
 
             return product.Stock >= quantity;

--- a/Backend/ProyectoBase.Infrastructure/Authentication/TokenService.cs
+++ b/Backend/ProyectoBase.Infrastructure/Authentication/TokenService.cs
@@ -12,7 +12,7 @@ using ProyectoBase.Application.Options;
 namespace ProyectoBase.Infrastructure.Authentication;
 
 /// <summary>
-/// Provides utilities to generate JSON Web Tokens for authenticated users.
+/// Proporciona utilidades para generar tokens JSON Web para usuarios autenticados.
 /// </summary>
 public class TokenService : ITokenService
 {
@@ -20,9 +20,9 @@ public class TokenService : ITokenService
     private readonly SigningCredentials _signingCredentials;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="TokenService"/> class.
+    /// Inicializa una nueva instancia de la clase <see cref="TokenService"/>.
     /// </summary>
-    /// <param name="options">The JWT configuration options.</param>
+    /// <param name="options">Las opciones de configuración de JWT.</param>
     public TokenService(IOptions<JwtOptions> options)
     {
         ArgumentNullException.ThrowIfNull(options);
@@ -30,7 +30,7 @@ public class TokenService : ITokenService
 
         if (string.IsNullOrWhiteSpace(_options.Key))
         {
-            throw new InvalidOperationException("JWT signing key configuration is required.");
+            throw new InvalidOperationException("Se requiere configurar la clave de firma para JWT.");
         }
 
         var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_options.Key));

--- a/Backend/ProyectoBase.Infrastructure/DependencyInjection.cs
+++ b/Backend/ProyectoBase.Infrastructure/DependencyInjection.cs
@@ -13,7 +13,7 @@ using ProyectoBase.Infrastructure.Persistence.Repositories;
 namespace ProyectoBase.Infrastructure;
 
 /// <summary>
-/// Provides extension methods to register infrastructure services and dependencies.
+/// Proporciona métodos de extensión para registrar los servicios y dependencias de la infraestructura.
 /// </summary>
 public static class DependencyInjection
 {
@@ -24,11 +24,11 @@ public static class DependencyInjection
     private const string RepositoryWritePolicyName = "ProductRepository.Write";
 
     /// <summary>
-    /// Registers the services required by the infrastructure layer.
+    /// Registra los servicios necesarios para la capa de infraestructura.
     /// </summary>
-    /// <param name="services">The service collection to configure.</param>
-    /// <param name="configuration">The application configuration source.</param>
-    /// <returns>The configured <see cref="IServiceCollection"/>.</returns>
+    /// <param name="services">La colección de servicios que se configurará.</param>
+    /// <param name="configuration">La fuente de configuración de la aplicación.</param>
+    /// <returns>La instancia configurada de <see cref="IServiceCollection"/>.</returns>
     public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(services);
@@ -38,7 +38,7 @@ public static class DependencyInjection
 
         if (string.IsNullOrWhiteSpace(connectionString))
         {
-            throw new InvalidOperationException($"Connection string '{DefaultConnectionName}' was not found.");
+            throw new InvalidOperationException($"No se encontró la cadena de conexión '{DefaultConnectionName}'.");
         }
 
         services.AddDbContext<ApplicationDbContext>(options =>
@@ -71,7 +71,7 @@ public static class DependencyInjection
                 sleepDurationProvider: attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt - 1)),
                 onRetry: (exception, timeSpan, retryCount, context) =>
                 {
-                    logger.LogWarning(exception, "Retry {RetryCount} executed after {Delay} seconds.", retryCount, timeSpan.TotalSeconds);
+                    logger.LogWarning(exception, "Reintento {RetryCount} ejecutado después de {Delay} segundos.", retryCount, timeSpan.TotalSeconds);
                 });
 
             var circuitBreakerPolicy = Policy.Handle<Exception>().CircuitBreakerAsync(
@@ -79,10 +79,10 @@ public static class DependencyInjection
                 durationOfBreak: TimeSpan.FromSeconds(30),
                 onBreak: (exception, breakDelay) =>
                 {
-                    logger.LogError(exception, "Circuit opened for {Delay} seconds due to repeated failures.", breakDelay.TotalSeconds);
+                    logger.LogError(exception, "Circuito abierto durante {Delay} segundos debido a fallas reiteradas.", breakDelay.TotalSeconds);
                 },
-                onReset: () => logger.LogInformation("Circuit closed: operations have stabilized."),
-                onHalfOpen: () => logger.LogInformation("Circuit half-open: next call is a trial."));
+                onReset: () => logger.LogInformation("Circuito cerrado: las operaciones se estabilizaron."),
+                onHalfOpen: () => logger.LogInformation("Circuito medio abierto: la siguiente llamada es de prueba."));
 
             registry.Add(RetryPolicyName, retryPolicy);
             registry.Add(CircuitBreakerPolicyName, circuitBreakerPolicy);

--- a/Backend/ProyectoBase.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/Backend/ProyectoBase.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -5,29 +5,29 @@ using ProyectoBase.Infrastructure.Persistence.Configurations;
 namespace ProyectoBase.Infrastructure.Persistence
 {
     /// <summary>
-    /// Represents the Entity Framework Core database context responsible for managing
-    /// the persistence layer of the application.
+    /// Representa el contexto de base de datos de Entity Framework Core encargado de administrar
+    /// la capa de persistencia de la aplicación.
     /// </summary>
     public class ApplicationDbContext : DbContext
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ApplicationDbContext"/> class.
+        /// Inicializa una nueva instancia de la clase <see cref="ApplicationDbContext"/>.
         /// </summary>
-        /// <param name="options">The options to be used by the <see cref="DbContext"/>.</param>
+        /// <param name="options">Las opciones que utilizará el <see cref="DbContext"/>.</param>
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
             : base(options)
         {
         }
 
         /// <summary>
-        /// Gets or sets the set of <see cref="Product"/> entities tracked by the context.
+        /// Obtiene o establece el conjunto de entidades <see cref="Product"/> administradas por el contexto.
         /// </summary>
         public DbSet<Product> Products { get; set; } = null!;
 
         /// <summary>
-        /// Configures the model that maps the domain entities to the database schema.
+        /// Configura el modelo que vincula las entidades de dominio con el esquema de la base de datos.
         /// </summary>
-        /// <param name="modelBuilder">The builder used to construct the model for the context.</param>
+        /// <param name="modelBuilder">El generador utilizado para construir el modelo del contexto.</param>
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);

--- a/Backend/ProyectoBase.Infrastructure/Persistence/Configurations/ProductConfiguration.cs
+++ b/Backend/ProyectoBase.Infrastructure/Persistence/Configurations/ProductConfiguration.cs
@@ -5,14 +5,14 @@ using ProyectoBase.Domain.Entities;
 namespace ProyectoBase.Infrastructure.Persistence.Configurations
 {
     /// <summary>
-    /// Defines the entity framework mapping configuration for <see cref="Product"/> entities.
+    /// Define la configuración de mapeo de Entity Framework para las entidades <see cref="Product"/>.
     /// </summary>
     public class ProductConfiguration : IEntityTypeConfiguration<Product>
     {
         /// <summary>
-        /// Configures the entity type builder with the mapping rules for the <see cref="Product"/> entity.
+        /// Configura el generador de tipos de entidad con las reglas de mapeo para la entidad <see cref="Product"/>.
         /// </summary>
-        /// <param name="builder">The builder that is used to configure the entity type.</param>
+        /// <param name="builder">El generador que se utiliza para configurar el tipo de entidad.</param>
         public void Configure(EntityTypeBuilder<Product> builder)
         {
             builder.ToTable("Products");

--- a/Backend/ProyectoBase.Infrastructure/Persistence/Migrations/20241010120000_InitialCreate.cs
+++ b/Backend/ProyectoBase.Infrastructure/Persistence/Migrations/20241010120000_InitialCreate.cs
@@ -4,14 +4,14 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace ProyectoBase.Infrastructure.Persistence.Migrations
 {
     /// <summary>
-    /// Defines the initial database schema for the application including the Products table.
+    /// Define el esquema inicial de la base de datos para la aplicación, incluida la tabla de productos.
     /// </summary>
     public partial class InitialCreate : Migration
     {
         /// <summary>
-        /// Builds the database objects required for the initial release of the application.
+        /// Crea los objetos de base de datos necesarios para la primera versión de la aplicación.
         /// </summary>
-        /// <param name="migrationBuilder">The builder used to construct the database schema.</param>
+        /// <param name="migrationBuilder">El generador utilizado para construir el esquema de la base de datos.</param>
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
@@ -31,9 +31,9 @@ namespace ProyectoBase.Infrastructure.Persistence.Migrations
         }
 
         /// <summary>
-        /// Removes the database objects created in the <see cref="Up(MigrationBuilder)"/> method.
+        /// Elimina los objetos de base de datos creados en el método <see cref="Up(MigrationBuilder)"/>.
         /// </summary>
-        /// <param name="migrationBuilder">The builder used to drop the database schema.</param>
+        /// <param name="migrationBuilder">El generador utilizado para eliminar el esquema de la base de datos.</param>
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(

--- a/Backend/ProyectoBase.Infrastructure/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Backend/ProyectoBase.Infrastructure/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -8,15 +8,15 @@ using ProyectoBase.Infrastructure.Persistence;
 namespace ProyectoBase.Infrastructure.Persistence.Migrations
 {
     /// <summary>
-    /// Represents the Entity Framework Core model snapshot for the application database context.
+    /// Representa la instantánea del modelo de Entity Framework Core para el contexto de base de datos de la aplicación.
     /// </summary>
     [DbContext(typeof(ApplicationDbContext))]
     internal class ApplicationDbContextModelSnapshot : ModelSnapshot
     {
         /// <summary>
-        /// Builds the model used to generate database migrations.
+        /// Construye el modelo que se utiliza para generar las migraciones de base de datos.
         /// </summary>
-        /// <param name="modelBuilder">The model builder used to configure the entity mappings.</param>
+        /// <param name="modelBuilder">El generador del modelo empleado para configurar el mapeo de las entidades.</param>
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618

--- a/Backend/ProyectoBase.Infrastructure/Persistence/Repositories/ProductRepository.cs
+++ b/Backend/ProyectoBase.Infrastructure/Persistence/Repositories/ProductRepository.cs
@@ -9,16 +9,16 @@ using ProyectoBase.Domain.Entities;
 namespace ProyectoBase.Infrastructure.Persistence.Repositories
 {
     /// <summary>
-    /// Provides Entity Framework Core based persistence operations for <see cref="Product"/> entities.
+    /// Proporciona operaciones de persistencia basadas en Entity Framework Core para las entidades <see cref="Product"/>.
     /// </summary>
     public class ProductRepository : IProductRepository
     {
         private readonly ApplicationDbContext _context;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ProductRepository"/> class.
+        /// Inicializa una nueva instancia de la clase <see cref="ProductRepository"/>.
         /// </summary>
-        /// <param name="context">The database context used to interact with the persistence store.</param>
+        /// <param name="context">El contexto de base de datos utilizado para interactuar con el almacén de persistencia.</param>
         public ProductRepository(ApplicationDbContext context)
         {
             _context = context;

--- a/Backend/ProyectoBase.Infrastructure/Persistence/Repositories/ResilientProductRepository.cs
+++ b/Backend/ProyectoBase.Infrastructure/Persistence/Repositories/ResilientProductRepository.cs
@@ -9,7 +9,7 @@ using ProyectoBase.Domain.Entities;
 namespace ProyectoBase.Infrastructure.Persistence.Repositories;
 
 /// <summary>
-/// Decorates an <see cref="IProductRepository"/> instance with resilience policies provided by Polly.
+/// Decora una instancia de <see cref="IProductRepository"/> con políticas de resiliencia proporcionadas por Polly.
 /// </summary>
 public class ResilientProductRepository : IProductRepository
 {
@@ -18,11 +18,11 @@ public class ResilientProductRepository : IProductRepository
     private readonly IAsyncPolicy _getPolicy;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ResilientProductRepository"/> class.
+    /// Inicializa una nueva instancia de la clase <see cref="ResilientProductRepository"/>.
     /// </summary>
-    /// <param name="innerRepository">The repository to decorate.</param>
-    /// <param name="writePolicy">The policy that should be applied to write operations.</param>
-    /// <param name="getPolicy">The policy that should be applied to read operations.</param>
+    /// <param name="innerRepository">El repositorio que se decorará.</param>
+    /// <param name="writePolicy">La política que se aplicará a las operaciones de escritura.</param>
+    /// <param name="getPolicy">La política que se aplicará a las operaciones de lectura.</param>
     public ResilientProductRepository(
         IProductRepository innerRepository,
         IAsyncPolicy writePolicy,


### PR DESCRIPTION
## Summary
- traducir los comentarios XML y mensajes de excepciones en las capas Domain, Application e Infrastructure a terminología española consistente
- actualizar los mensajes de validación, logging y respuestas de middleware/controladores para exponer textos claros en español, incluyendo Swagger y documentación
- ajustar la configuración de Swagger y las validaciones para reflejar la localización en los contratos expuestos

## Testing
- `dotnet build ProyectoBase.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68deec6fb92c832e857bec89be92f42d