### PR TITLE
Renombrar proyectos backend con prefijo ProyectoBase.Api

### DIFF
--- a/Backend/ProyectoBase.Api.IntegrationTests/Controllers/V1/ProductsControllerTests.cs
+++ b/Backend/ProyectoBase.Api.IntegrationTests/Controllers/V1/ProductsControllerTests.cs
@@ -7,7 +7,7 @@ using System.Net.Http.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using ProyectoBase.Api.IntegrationTests.Infrastructure;
-using ProyectoBase.Application.DTOs;
+using ProyectoBase.Api.Application.DTOs;
 using Xunit;
 
 namespace ProyectoBase.Api.IntegrationTests.Controllers.V1;

--- a/Backend/ProyectoBase.Api.IntegrationTests/Infrastructure/CustomWebApplicationFactory.cs
+++ b/Backend/ProyectoBase.Api.IntegrationTests/Infrastructure/CustomWebApplicationFactory.cs
@@ -7,9 +7,9 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using ProyectoBase.Api;
-using ProyectoBase.Domain.Entities;
-using ProyectoBase.Infrastructure.Persistence;
+using ProyectoBase.Api.Api;
+using ProyectoBase.Api.Domain.Entities;
+using ProyectoBase.Api.Infrastructure.Persistence;
 
 namespace ProyectoBase.Api.IntegrationTests.Infrastructure;
 

--- a/Backend/ProyectoBase.Api.IntegrationTests/Logging/SafeRequestHeadersLayoutRendererTests.cs
+++ b/Backend/ProyectoBase.Api.IntegrationTests/Logging/SafeRequestHeadersLayoutRendererTests.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Nodes;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
-using ProyectoBase.Api.Logging;
+using ProyectoBase.Api.Api.Logging;
 using Xunit;
 
 namespace ProyectoBase.Api.IntegrationTests.Logging;

--- a/Backend/ProyectoBase.Api.IntegrationTests/Logging/SafeUserClaimsLayoutRendererTests.cs
+++ b/Backend/ProyectoBase.Api.IntegrationTests/Logging/SafeUserClaimsLayoutRendererTests.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
-using ProyectoBase.Api.Logging;
+using ProyectoBase.Api.Api.Logging;
 using Xunit;
 
 namespace ProyectoBase.Api.IntegrationTests.Logging;

--- a/Backend/ProyectoBase.Api.IntegrationTests/ProyectoBase.Api.IntegrationTests.csproj
+++ b/Backend/ProyectoBase.Api.IntegrationTests/ProyectoBase.Api.IntegrationTests.csproj
@@ -4,6 +4,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AssemblyName>ProyectoBase.Api.IntegrationTests</AssemblyName>
+    <RootNamespace>ProyectoBase.Api.IntegrationTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
@@ -26,9 +28,9 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ProyectoBase.Api\ProyectoBase.Api.csproj" />
-    <ProjectReference Include="..\ProyectoBase.Application\ProyectoBase.Application.csproj" />
-    <ProjectReference Include="..\ProyectoBase.Domain\ProyectoBase.Domain.csproj" />
-    <ProjectReference Include="..\ProyectoBase.Infrastructure\ProyectoBase.Infrastructure.csproj" />
+    <ProjectReference Include="..\ProyectoBase.Api\ProyectoBase.Api.Api.csproj" />
+    <ProjectReference Include="..\ProyectoBase.Application\ProyectoBase.Api.Application.csproj" />
+    <ProjectReference Include="..\ProyectoBase.Domain\ProyectoBase.Api.Domain.csproj" />
+    <ProjectReference Include="..\ProyectoBase.Infrastructure\ProyectoBase.Api.Infrastructure.csproj" />
   </ItemGroup>
 </Project>

--- a/Backend/ProyectoBase.Api/Controllers/V1/ProductsController.cs
+++ b/Backend/ProyectoBase.Api/Controllers/V1/ProductsController.cs
@@ -9,11 +9,11 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using ProyectoBase.Application.Abstractions;
-using ProyectoBase.Application.DTOs;
-using ProyectoBase.Domain.Exceptions;
+using ProyectoBase.Api.Application.Abstractions;
+using ProyectoBase.Api.Application.DTOs;
+using ProyectoBase.Api.Domain.Exceptions;
 
-namespace ProyectoBase.Api.Controllers.V1;
+namespace ProyectoBase.Api.Api.Controllers.V1;
 
 /// <summary>
 /// Expone endpoints para administrar recursos de productos.

--- a/Backend/ProyectoBase.Api/Logging/SafeRequestHeadersLayoutRenderer.cs
+++ b/Backend/ProyectoBase.Api/Logging/SafeRequestHeadersLayoutRenderer.cs
@@ -9,7 +9,7 @@ using NLog;
 using NLog.LayoutRenderers;
 using NLog.Web.LayoutRenderers;
 
-namespace ProyectoBase.Api.Logging;
+namespace ProyectoBase.Api.Api.Logging;
 
 /// <summary>
 /// Representa un layout renderer que emite los encabezados de la solicitud HTTP ocultando los valores sensibles.

--- a/Backend/ProyectoBase.Api/Logging/SafeUserClaimsLayoutRenderer.cs
+++ b/Backend/ProyectoBase.Api/Logging/SafeUserClaimsLayoutRenderer.cs
@@ -7,7 +7,7 @@ using NLog;
 using NLog.LayoutRenderers;
 using NLog.Web.LayoutRenderers;
 
-namespace ProyectoBase.Api.Logging;
+namespace ProyectoBase.Api.Api.Logging;
 
 /// <summary>
 /// Representa un layout renderer que expone los claims del usuario autenticado sin revelar información personal.

--- a/Backend/ProyectoBase.Api/Middlewares/ExceptionHandlingMiddleware.cs
+++ b/Backend/ProyectoBase.Api/Middlewares/ExceptionHandlingMiddleware.cs
@@ -4,9 +4,9 @@ using System.Linq;
 using FluentValidation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using ProyectoBase.Domain.Exceptions;
+using ProyectoBase.Api.Domain.Exceptions;
 
-namespace ProyectoBase.Api.Middlewares;
+namespace ProyectoBase.Api.Api.Middlewares;
 
 /// <summary>
 /// Middleware responsable de traducir las excepciones no controladas en respuestas HTTP estandarizadas.

--- a/Backend/ProyectoBase.Api/Options/ConnectionStringsOptions.cs
+++ b/Backend/ProyectoBase.Api/Options/ConnectionStringsOptions.cs
@@ -1,4 +1,4 @@
-namespace ProyectoBase.Api.Options;
+namespace ProyectoBase.Api.Api.Options;
 
 public class ConnectionStringsOptions
 {

--- a/Backend/ProyectoBase.Api/Options/RedisOptions.cs
+++ b/Backend/ProyectoBase.Api/Options/RedisOptions.cs
@@ -1,4 +1,4 @@
-namespace ProyectoBase.Api.Options;
+namespace ProyectoBase.Api.Api.Options;
 
 public class RedisOptions
 {

--- a/Backend/ProyectoBase.Api/Program.cs
+++ b/Backend/ProyectoBase.Api/Program.cs
@@ -12,14 +12,14 @@ using Microsoft.OpenApi.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using NLog.Web;
-using ProyectoBase.Api.Middlewares;
-using ProyectoBase.Api.Options;
-using ProyectoBase.Api.Swagger;
-using ProyectoBase.Api.Swagger.Filters;
-using ProyectoBase.Application;
-using ProyectoBase.Application.Options;
-using ProyectoBase.Infrastructure;
-using ProyectoBase.Domain.Entities;
+using ProyectoBase.Api.Api.Middlewares;
+using ProyectoBase.Api.Api.Options;
+using ProyectoBase.Api.Api.Swagger;
+using ProyectoBase.Api.Api.Swagger.Filters;
+using ProyectoBase.Api.Application;
+using ProyectoBase.Api.Application.Options;
+using ProyectoBase.Api.Infrastructure;
+using ProyectoBase.Api.Domain.Entities;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -34,9 +34,9 @@ static IEnumerable<string> GetXmlDocumentationPaths()
     var assemblies = new[]
     {
         typeof(Program).Assembly,
-        typeof(ProyectoBase.Application.DependencyInjection).Assembly,
+        typeof(ProyectoBase.Api.Application.DependencyInjection).Assembly,
         typeof(Product).Assembly,
-        typeof(ProyectoBase.Infrastructure.DependencyInjection).Assembly,
+        typeof(ProyectoBase.Api.Infrastructure.DependencyInjection).Assembly,
     };
 
     return assemblies
@@ -58,8 +58,8 @@ builder.Services.AddSwaggerGen(options =>
     options.MapCodeEnumsFromAssemblies(
         typeof(Program).Assembly,
         typeof(Product).Assembly,
-        typeof(ProyectoBase.Application.DependencyInjection).Assembly,
-        typeof(ProyectoBase.Infrastructure.DependencyInjection).Assembly);
+        typeof(ProyectoBase.Api.Application.DependencyInjection).Assembly,
+        typeof(ProyectoBase.Api.Infrastructure.DependencyInjection).Assembly);
 
     options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
     {

--- a/Backend/ProyectoBase.Api/ProyectoBase.Api.Api.csproj
+++ b/Backend/ProyectoBase.Api/ProyectoBase.Api.Api.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -8,8 +7,9 @@
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <CopyDocumentationFileToOutputDirectory>Always</CopyDocumentationFileToOutputDirectory>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AssemblyName>ProyectoBase.Api.Api</AssemblyName>
+    <RootNamespace>ProyectoBase.Api.Api</RootNamespace>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.20" />
@@ -27,15 +27,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\ProyectoBase.Application\ProyectoBase.Application.csproj" />
+    <ProjectReference Include="..\ProyectoBase.Application\ProyectoBase.Api.Application.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="nlog.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/Backend/ProyectoBase.Api/Swagger/ConfigureSwaggerOptions.cs
+++ b/Backend/ProyectoBase.Api/Swagger/ConfigureSwaggerOptions.cs
@@ -3,7 +3,7 @@ using Microsoft.OpenApi.Models;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
-namespace ProyectoBase.Api.Swagger;
+namespace ProyectoBase.Api.Api.Swagger;
 
 /// <summary>
 /// Configura los documentos de Swagger según las versiones disponibles de la API.

--- a/Backend/ProyectoBase.Api/Swagger/ErrorResponse.cs
+++ b/Backend/ProyectoBase.Api/Swagger/ErrorResponse.cs
@@ -1,4 +1,4 @@
-namespace ProyectoBase.Api.Swagger;
+namespace ProyectoBase.Api.Api.Swagger;
 
 /// <summary>
 /// Representa el contrato de error estandarizado que devuelve la API.

--- a/Backend/ProyectoBase.Api/Swagger/Filters/DefaultResponsesOperationFilter.cs
+++ b/Backend/ProyectoBase.Api/Swagger/Filters/DefaultResponsesOperationFilter.cs
@@ -2,10 +2,10 @@ using System;
 using System.Globalization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.OpenApi.Models;
-using ProyectoBase.Api.Swagger;
+using ProyectoBase.Api.Api.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
-namespace ProyectoBase.Api.Swagger.Filters;
+namespace ProyectoBase.Api.Api.Swagger.Filters;
 
 /// <summary>
 /// Garantiza que las respuestas de error predeterminadas queden documentadas para todas las operaciones.

--- a/Backend/ProyectoBase.Api/Swagger/SwaggerGenOptionsExtensions.cs
+++ b/Backend/ProyectoBase.Api/Swagger/SwaggerGenOptionsExtensions.cs
@@ -7,7 +7,7 @@ using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
-namespace ProyectoBase.Api.Swagger;
+namespace ProyectoBase.Api.Api.Swagger;
 
 /// <summary>
 /// Proporciona métodos auxiliares para configurar la generación de Swagger.

--- a/Backend/ProyectoBase.Application.Tests/Middlewares/ExceptionHandlingMiddlewareTests.cs
+++ b/Backend/ProyectoBase.Application.Tests/Middlewares/ExceptionHandlingMiddlewareTests.cs
@@ -4,12 +4,12 @@ using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
-using ProyectoBase.Api.Middlewares;
-using DomainNotFoundException = ProyectoBase.Domain.Exceptions.NotFoundException;
-using DomainValidationException = ProyectoBase.Domain.Exceptions.ValidationException;
+using ProyectoBase.Api.Api.Middlewares;
+using DomainNotFoundException = ProyectoBase.Api.Domain.Exceptions.NotFoundException;
+using DomainValidationException = ProyectoBase.Api.Domain.Exceptions.ValidationException;
 using Xunit;
 
-namespace ProyectoBase.Application.Tests.Middlewares;
+namespace ProyectoBase.Api.Application.Tests.Middlewares;
 
 public class ExceptionHandlingMiddlewareTests
 {

--- a/Backend/ProyectoBase.Application.Tests/ProyectoBase.Api.Application.Tests.csproj
+++ b/Backend/ProyectoBase.Application.Tests/ProyectoBase.Api.Application.Tests.csproj
@@ -7,27 +7,28 @@
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <CopyDocumentationFileToOutputDirectory>Always</CopyDocumentationFileToOutputDirectory>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AssemblyName>ProyectoBase.Api.Application.Tests</AssemblyName>
+    <RootNamespace>ProyectoBase.Api.Application.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9">
+    <PackageReference Include="FluentValidation.TestHelper" Version="11.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.10" />
-    <PackageReference Include="Polly" Version="7.2.4" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ProyectoBase.Application\ProyectoBase.Application.csproj" />
-    <ProjectReference Include="..\ProyectoBase.Domain\ProyectoBase.Domain.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Persistence\Migrations\**\*.cs" />
+    <ProjectReference Include="..\ProyectoBase.Api\ProyectoBase.Api.Api.csproj" />
+    <ProjectReference Include="..\ProyectoBase.Application\ProyectoBase.Api.Application.csproj" />
   </ItemGroup>
 </Project>

--- a/Backend/ProyectoBase.Application.Tests/Validators/CreateProductDtoValidatorTests.cs
+++ b/Backend/ProyectoBase.Application.Tests/Validators/CreateProductDtoValidatorTests.cs
@@ -1,9 +1,9 @@
 using FluentValidation.TestHelper;
-using ProyectoBase.Application.DTOs;
-using ProyectoBase.Application.Validators;
+using ProyectoBase.Api.Application.DTOs;
+using ProyectoBase.Api.Application.Validators;
 using Xunit;
 
-namespace ProyectoBase.Application.Tests.Validators;
+namespace ProyectoBase.Api.Application.Tests.Validators;
 
 /// <summary>
 /// Contains unit tests for <see cref="CreateProductDtoValidator"/>.

--- a/Backend/ProyectoBase.Application.Tests/Validators/UpdateProductDtoValidatorTests.cs
+++ b/Backend/ProyectoBase.Application.Tests/Validators/UpdateProductDtoValidatorTests.cs
@@ -1,9 +1,9 @@
 using FluentValidation.TestHelper;
-using ProyectoBase.Application.DTOs;
-using ProyectoBase.Application.Validators;
+using ProyectoBase.Api.Application.DTOs;
+using ProyectoBase.Api.Application.Validators;
 using Xunit;
 
-namespace ProyectoBase.Application.Tests.Validators;
+namespace ProyectoBase.Api.Application.Tests.Validators;
 
 /// <summary>
 /// Contains unit tests for <see cref="UpdateProductDtoValidator"/>.

--- a/Backend/ProyectoBase.Application/Abstractions/IProductRepository.cs
+++ b/Backend/ProyectoBase.Application/Abstractions/IProductRepository.cs
@@ -2,9 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using ProyectoBase.Domain.Entities;
+using ProyectoBase.Api.Domain.Entities;
 
-namespace ProyectoBase.Application.Abstractions
+namespace ProyectoBase.Api.Application.Abstractions
 {
     /// <summary>
     /// Proporciona operaciones de acceso a datos para entidades <see cref="Product"/>.

--- a/Backend/ProyectoBase.Application/Abstractions/IProductService.cs
+++ b/Backend/ProyectoBase.Application/Abstractions/IProductService.cs
@@ -2,9 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using ProyectoBase.Application.DTOs;
+using ProyectoBase.Api.Application.DTOs;
 
-namespace ProyectoBase.Application.Abstractions
+namespace ProyectoBase.Api.Application.Abstractions
 {
     /// <summary>
     /// Define las operaciones disponibles para administrar productos dentro de la capa de aplicación.

--- a/Backend/ProyectoBase.Application/Abstractions/ITokenService.cs
+++ b/Backend/ProyectoBase.Application/Abstractions/ITokenService.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Security.Claims;
 
-namespace ProyectoBase.Application.Abstractions;
+namespace ProyectoBase.Api.Application.Abstractions;
 
 /// <summary>
 /// Proporciona funcionalidad para crear tokens JSON Web para usuarios autenticados.

--- a/Backend/ProyectoBase.Application/DTOs/ProductCreateDto.cs
+++ b/Backend/ProyectoBase.Application/DTOs/ProductCreateDto.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 
-namespace ProyectoBase.Application.DTOs
+namespace ProyectoBase.Api.Application.DTOs
 {
     /// <summary>
     /// Representa los datos necesarios para crear un nuevo producto.

--- a/Backend/ProyectoBase.Application/DTOs/ProductResponseDto.cs
+++ b/Backend/ProyectoBase.Application/DTOs/ProductResponseDto.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace ProyectoBase.Application.DTOs
+namespace ProyectoBase.Api.Application.DTOs
 {
     /// <summary>
     /// Representa los datos de producto devueltos por los servicios de la aplicación.

--- a/Backend/ProyectoBase.Application/DTOs/ProductUpdateDto.cs
+++ b/Backend/ProyectoBase.Application/DTOs/ProductUpdateDto.cs
@@ -1,7 +1,7 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 
-namespace ProyectoBase.Application.DTOs
+namespace ProyectoBase.Api.Application.DTOs
 {
     /// <summary>
     /// Representa la información necesaria para actualizar un producto existente.

--- a/Backend/ProyectoBase.Application/DependencyInjection.cs
+++ b/Backend/ProyectoBase.Application/DependencyInjection.cs
@@ -3,10 +3,10 @@ using System.Reflection;
 using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
-using ProyectoBase.Application.Abstractions;
-using ProyectoBase.Application.Services.Products;
+using ProyectoBase.Api.Application.Abstractions;
+using ProyectoBase.Api.Application.Services.Products;
 
-namespace ProyectoBase.Application;
+namespace ProyectoBase.Api.Application;
 
 /// <summary>
 /// Proporciona métodos de extensión para registrar los servicios de la capa de aplicación en el contenedor de dependencias.

--- a/Backend/ProyectoBase.Application/Exceptions/ApplicationLayerException.cs
+++ b/Backend/ProyectoBase.Application/Exceptions/ApplicationLayerException.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace ProyectoBase.Application.Exceptions;
+namespace ProyectoBase.Api.Application.Exceptions;
 
 /// <summary>
 /// Representa un error inesperado ocurrido dentro de la capa de aplicación.

--- a/Backend/ProyectoBase.Application/Exceptions/ProductServiceException.cs
+++ b/Backend/ProyectoBase.Application/Exceptions/ProductServiceException.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace ProyectoBase.Application.Exceptions;
+namespace ProyectoBase.Api.Application.Exceptions;
 
 /// <summary>
 /// Representa errores inesperados que se producen al operar con productos en la capa de aplicación.

--- a/Backend/ProyectoBase.Application/Mappings/ProductProfile.cs
+++ b/Backend/ProyectoBase.Application/Mappings/ProductProfile.cs
@@ -1,9 +1,9 @@
 using System;
 using AutoMapper;
-using ProyectoBase.Application.DTOs;
-using ProyectoBase.Domain.Entities;
+using ProyectoBase.Api.Application.DTOs;
+using ProyectoBase.Api.Domain.Entities;
 
-namespace ProyectoBase.Application.Mappings;
+namespace ProyectoBase.Api.Application.Mappings;
 
 /// <summary>
 /// Define los mapeos entre las entidades de dominio de productos y sus DTO.

--- a/Backend/ProyectoBase.Application/Options/JwtOptions.cs
+++ b/Backend/ProyectoBase.Application/Options/JwtOptions.cs
@@ -1,4 +1,4 @@
-namespace ProyectoBase.Application.Options;
+namespace ProyectoBase.Api.Application.Options;
 
 /// <summary>
 /// Representa la configuración necesaria para generar y validar tokens JWT.

--- a/Backend/ProyectoBase.Application/ProyectoBase.Api.Application.csproj
+++ b/Backend/ProyectoBase.Application/ProyectoBase.Api.Application.csproj
@@ -7,9 +7,11 @@
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <CopyDocumentationFileToOutputDirectory>Always</CopyDocumentationFileToOutputDirectory>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AssemblyName>ProyectoBase.Api.Application</AssemblyName>
+    <RootNamespace>ProyectoBase.Api.Application</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ProyectoBase.Domain\ProyectoBase.Domain.csproj" />
+    <ProjectReference Include="..\ProyectoBase.Domain\ProyectoBase.Api.Domain.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.9.0" />

--- a/Backend/ProyectoBase.Application/Services/Products/CreateProductCommand.cs
+++ b/Backend/ProyectoBase.Application/Services/Products/CreateProductCommand.cs
@@ -1,7 +1,7 @@
 using MediatR;
-using ProyectoBase.Application.DTOs;
+using ProyectoBase.Api.Application.DTOs;
 
-namespace ProyectoBase.Application.Services.Products
+namespace ProyectoBase.Api.Application.Services.Products
 {
     /// <summary>
     /// Comando utilizado para solicitar la creación de un nuevo producto.

--- a/Backend/ProyectoBase.Application/Services/Products/CreateProductCommandHandler.cs
+++ b/Backend/ProyectoBase.Application/Services/Products/CreateProductCommandHandler.cs
@@ -1,10 +1,10 @@
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
-using ProyectoBase.Application.Abstractions;
-using ProyectoBase.Application.DTOs;
+using ProyectoBase.Api.Application.Abstractions;
+using ProyectoBase.Api.Application.DTOs;
 
-namespace ProyectoBase.Application.Services.Products
+namespace ProyectoBase.Api.Application.Services.Products
 {
     /// <summary>
     /// Atiende solicitudes de <see cref="CreateProductCommand"/> delegando en el servicio de productos.

--- a/Backend/ProyectoBase.Application/Services/Products/ProductService.cs
+++ b/Backend/ProyectoBase.Application/Services/Products/ProductService.cs
@@ -6,13 +6,13 @@ using System.Threading.Tasks;
 using AutoMapper;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
-using ProyectoBase.Application.Abstractions;
-using ProyectoBase.Application.DTOs;
-using ProyectoBase.Application.Exceptions;
-using ProyectoBase.Domain.Entities;
-using ProyectoBase.Domain.Exceptions;
+using ProyectoBase.Api.Application.Abstractions;
+using ProyectoBase.Api.Application.DTOs;
+using ProyectoBase.Api.Application.Exceptions;
+using ProyectoBase.Api.Domain.Entities;
+using ProyectoBase.Api.Domain.Exceptions;
 
-namespace ProyectoBase.Application.Services.Products;
+namespace ProyectoBase.Api.Application.Services.Products;
 
 /// <summary>
 /// Proporciona operaciones de nivel de aplicación para administrar productos.

--- a/Backend/ProyectoBase.Application/Validators/CreateProductDtoValidator.cs
+++ b/Backend/ProyectoBase.Application/Validators/CreateProductDtoValidator.cs
@@ -1,7 +1,7 @@
 using FluentValidation;
-using ProyectoBase.Application.DTOs;
+using ProyectoBase.Api.Application.DTOs;
 
-namespace ProyectoBase.Application.Validators
+namespace ProyectoBase.Api.Application.Validators
 {
     /// <summary>
     /// Garantiza que las instancias de <see cref="ProductCreateDto"/> contengan datos válidos antes de ser procesadas.

--- a/Backend/ProyectoBase.Application/Validators/UpdateProductDtoValidator.cs
+++ b/Backend/ProyectoBase.Application/Validators/UpdateProductDtoValidator.cs
@@ -1,7 +1,7 @@
 using FluentValidation;
-using ProyectoBase.Application.DTOs;
+using ProyectoBase.Api.Application.DTOs;
 
-namespace ProyectoBase.Application.Validators
+namespace ProyectoBase.Api.Application.Validators
 {
     /// <summary>
     /// Garantiza que las instancias de <see cref="ProductUpdateDto"/> contengan datos válidos antes de ser procesadas.

--- a/Backend/ProyectoBase.Domain.Tests/Entities/ProductTests.cs
+++ b/Backend/ProyectoBase.Domain.Tests/Entities/ProductTests.cs
@@ -1,10 +1,10 @@
 using System;
 using FluentAssertions;
-using ProyectoBase.Domain.Entities;
-using ProyectoBase.Domain.Exceptions;
+using ProyectoBase.Api.Domain.Entities;
+using ProyectoBase.Api.Domain.Exceptions;
 using Xunit;
 
-namespace ProyectoBase.Domain.Tests.Entities;
+namespace ProyectoBase.Api.Domain.Tests.Entities;
 
 public class ProductTests
 {

--- a/Backend/ProyectoBase.Domain.Tests/ProyectoBase.Api.Domain.Tests.csproj
+++ b/Backend/ProyectoBase.Domain.Tests/ProyectoBase.Api.Domain.Tests.csproj
@@ -4,6 +4,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AssemblyName>ProyectoBase.Api.Domain.Tests</AssemblyName>
+    <RootNamespace>ProyectoBase.Api.Domain.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
@@ -24,6 +26,6 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ProyectoBase.Domain\ProyectoBase.Domain.csproj" />
+    <ProjectReference Include="..\ProyectoBase.Domain\ProyectoBase.Api.Domain.csproj" />
   </ItemGroup>
 </Project>

--- a/Backend/ProyectoBase.Domain.Tests/Services/ProductStockServiceTests.cs
+++ b/Backend/ProyectoBase.Domain.Tests/Services/ProductStockServiceTests.cs
@@ -3,13 +3,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
-using ProyectoBase.Domain.Entities;
-using ProyectoBase.Domain.Exceptions;
-using ProyectoBase.Domain.Repositories;
-using ProyectoBase.Domain.Services;
+using ProyectoBase.Api.Domain.Entities;
+using ProyectoBase.Api.Domain.Exceptions;
+using ProyectoBase.Api.Domain.Repositories;
+using ProyectoBase.Api.Domain.Services;
 using Xunit;
 
-namespace ProyectoBase.Domain.Tests.Services;
+namespace ProyectoBase.Api.Domain.Tests.Services;
 
 public class ProductStockServiceTests
 {

--- a/Backend/ProyectoBase.Domain/Entities/Product.cs
+++ b/Backend/ProyectoBase.Domain/Entities/Product.cs
@@ -1,7 +1,7 @@
 using System;
-using ProyectoBase.Domain.Exceptions;
+using ProyectoBase.Api.Domain.Exceptions;
 
-namespace ProyectoBase.Domain.Entities
+namespace ProyectoBase.Api.Domain.Entities
 {
     /// <summary>
     /// Representa un producto disponible para la venta.

--- a/Backend/ProyectoBase.Domain/Exceptions/DomainException.cs
+++ b/Backend/ProyectoBase.Domain/Exceptions/DomainException.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace ProyectoBase.Domain.Exceptions
+namespace ProyectoBase.Api.Domain.Exceptions
 {
     /// <summary>
     /// Representa errores que ocurren dentro de la capa de dominio.

--- a/Backend/ProyectoBase.Domain/Exceptions/NotFoundException.cs
+++ b/Backend/ProyectoBase.Domain/Exceptions/NotFoundException.cs
@@ -1,4 +1,4 @@
-namespace ProyectoBase.Domain.Exceptions
+namespace ProyectoBase.Api.Domain.Exceptions
 {
     /// <summary>
     /// Representa errores que ocurren cuando no se encuentra un recurso solicitado en el dominio.

--- a/Backend/ProyectoBase.Domain/Exceptions/ValidationException.cs
+++ b/Backend/ProyectoBase.Domain/Exceptions/ValidationException.cs
@@ -1,4 +1,4 @@
-namespace ProyectoBase.Domain.Exceptions
+namespace ProyectoBase.Api.Domain.Exceptions
 {
     /// <summary>
     /// Representa errores que ocurren cuando el dominio detecta datos no válidos.

--- a/Backend/ProyectoBase.Domain/ProyectoBase.Api.Domain.csproj
+++ b/Backend/ProyectoBase.Domain/ProyectoBase.Api.Domain.csproj
@@ -7,8 +7,9 @@
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <CopyDocumentationFileToOutputDirectory>Always</CopyDocumentationFileToOutputDirectory>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AssemblyName>ProyectoBase.Api.Domain</AssemblyName>
+    <RootNamespace>ProyectoBase.Api.Domain</RootNamespace>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
       <PrivateAssets>all</PrivateAssets>

--- a/Backend/ProyectoBase.Domain/Repositories/IProductReadRepository.cs
+++ b/Backend/ProyectoBase.Domain/Repositories/IProductReadRepository.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using ProyectoBase.Domain.Entities;
+using ProyectoBase.Api.Domain.Entities;
 
-namespace ProyectoBase.Domain.Repositories
+namespace ProyectoBase.Api.Domain.Repositories
 {
     /// <summary>
     /// Proporciona acceso de solo lectura a entidades <see cref="Product"/> desde un almacén de persistencia.

--- a/Backend/ProyectoBase.Domain/Services/ProductStockService.cs
+++ b/Backend/ProyectoBase.Domain/Services/ProductStockService.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using ProyectoBase.Domain.Entities;
-using ProyectoBase.Domain.Exceptions;
-using ProyectoBase.Domain.Repositories;
+using ProyectoBase.Api.Domain.Entities;
+using ProyectoBase.Api.Domain.Exceptions;
+using ProyectoBase.Api.Domain.Repositories;
 
-namespace ProyectoBase.Domain.Services
+namespace ProyectoBase.Api.Domain.Services
 {
     /// <summary>
     /// Proporciona operaciones de dominio relacionadas con la disponibilidad de inventario de productos.

--- a/Backend/ProyectoBase.Domain/WeatherForecast.cs
+++ b/Backend/ProyectoBase.Domain/WeatherForecast.cs
@@ -1,4 +1,4 @@
-namespace ProyectoBase.Domain;
+namespace ProyectoBase.Api.Domain;
 
 public record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
 {

--- a/Backend/ProyectoBase.Infrastructure/Authentication/TokenService.cs
+++ b/Backend/ProyectoBase.Infrastructure/Authentication/TokenService.cs
@@ -6,10 +6,10 @@ using System.Security.Claims;
 using System.Text;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
-using ProyectoBase.Application.Abstractions;
-using ProyectoBase.Application.Options;
+using ProyectoBase.Api.Application.Abstractions;
+using ProyectoBase.Api.Application.Options;
 
-namespace ProyectoBase.Infrastructure.Authentication;
+namespace ProyectoBase.Api.Infrastructure.Authentication;
 
 /// <summary>
 /// Proporciona utilidades para generar tokens JSON Web para usuarios autenticados.

--- a/Backend/ProyectoBase.Infrastructure/DependencyInjection.cs
+++ b/Backend/ProyectoBase.Infrastructure/DependencyInjection.cs
@@ -5,12 +5,12 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Polly;
 using Polly.Registry;
-using ProyectoBase.Application.Abstractions;
-using ProyectoBase.Infrastructure.Authentication;
-using ProyectoBase.Infrastructure.Persistence;
-using ProyectoBase.Infrastructure.Persistence.Repositories;
+using ProyectoBase.Api.Application.Abstractions;
+using ProyectoBase.Api.Infrastructure.Authentication;
+using ProyectoBase.Api.Infrastructure.Persistence;
+using ProyectoBase.Api.Infrastructure.Persistence.Repositories;
 
-namespace ProyectoBase.Infrastructure;
+namespace ProyectoBase.Api.Infrastructure;
 
 /// <summary>
 /// Proporciona métodos de extensión para registrar los servicios y dependencias de la infraestructura.

--- a/Backend/ProyectoBase.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/Backend/ProyectoBase.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -1,8 +1,8 @@
 using Microsoft.EntityFrameworkCore;
-using ProyectoBase.Domain.Entities;
-using ProyectoBase.Infrastructure.Persistence.Configurations;
+using ProyectoBase.Api.Domain.Entities;
+using ProyectoBase.Api.Infrastructure.Persistence.Configurations;
 
-namespace ProyectoBase.Infrastructure.Persistence
+namespace ProyectoBase.Api.Infrastructure.Persistence
 {
     /// <summary>
     /// Representa el contexto de base de datos de Entity Framework Core encargado de administrar

--- a/Backend/ProyectoBase.Infrastructure/Persistence/Configurations/ProductConfiguration.cs
+++ b/Backend/ProyectoBase.Infrastructure/Persistence/Configurations/ProductConfiguration.cs
@@ -1,8 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using ProyectoBase.Domain.Entities;
+using ProyectoBase.Api.Domain.Entities;
 
-namespace ProyectoBase.Infrastructure.Persistence.Configurations
+namespace ProyectoBase.Api.Infrastructure.Persistence.Configurations
 {
     /// <summary>
     /// Define la configuración de mapeo de Entity Framework para las entidades <see cref="Product"/>.

--- a/Backend/ProyectoBase.Infrastructure/Persistence/Migrations/20241010120000_InitialCreate.cs
+++ b/Backend/ProyectoBase.Infrastructure/Persistence/Migrations/20241010120000_InitialCreate.cs
@@ -1,7 +1,7 @@
 using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
-namespace ProyectoBase.Infrastructure.Persistence.Migrations
+namespace ProyectoBase.Api.Infrastructure.Persistence.Migrations
 {
     /// <summary>
     /// Define el esquema inicial de la base de datos para la aplicación, incluida la tabla de productos.

--- a/Backend/ProyectoBase.Infrastructure/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Backend/ProyectoBase.Infrastructure/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -3,9 +3,9 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using ProyectoBase.Infrastructure.Persistence;
+using ProyectoBase.Api.Infrastructure.Persistence;
 
-namespace ProyectoBase.Infrastructure.Persistence.Migrations
+namespace ProyectoBase.Api.Infrastructure.Persistence.Migrations
 {
     /// <summary>
     /// Representa la instantánea del modelo de Entity Framework Core para el contexto de base de datos de la aplicación.
@@ -22,7 +22,7 @@ namespace ProyectoBase.Infrastructure.Persistence.Migrations
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.9");
 
-            modelBuilder.Entity("ProyectoBase.Domain.Entities.Product", builder =>
+            modelBuilder.Entity("ProyectoBase.Api.Domain.Entities.Product", builder =>
             {
                 builder.Property<Guid>("Id")
                     .HasColumnType("uniqueidentifier");

--- a/Backend/ProyectoBase.Infrastructure/Persistence/Repositories/ProductRepository.cs
+++ b/Backend/ProyectoBase.Infrastructure/Persistence/Repositories/ProductRepository.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
-using ProyectoBase.Application.Abstractions;
-using ProyectoBase.Domain.Entities;
+using ProyectoBase.Api.Application.Abstractions;
+using ProyectoBase.Api.Domain.Entities;
 
-namespace ProyectoBase.Infrastructure.Persistence.Repositories
+namespace ProyectoBase.Api.Infrastructure.Persistence.Repositories
 {
     /// <summary>
     /// Proporciona operaciones de persistencia basadas en Entity Framework Core para las entidades <see cref="Product"/>.

--- a/Backend/ProyectoBase.Infrastructure/Persistence/Repositories/ResilientProductRepository.cs
+++ b/Backend/ProyectoBase.Infrastructure/Persistence/Repositories/ResilientProductRepository.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Polly;
-using ProyectoBase.Application.Abstractions;
-using ProyectoBase.Domain.Entities;
+using ProyectoBase.Api.Application.Abstractions;
+using ProyectoBase.Api.Domain.Entities;
 
-namespace ProyectoBase.Infrastructure.Persistence.Repositories;
+namespace ProyectoBase.Api.Infrastructure.Persistence.Repositories;
 
 /// <summary>
 /// Decora una instancia de <see cref="IProductRepository"/> con políticas de resiliencia proporcionadas por Polly.

--- a/Backend/ProyectoBase.Infrastructure/ProyectoBase.Api.Infrastructure.csproj
+++ b/Backend/ProyectoBase.Infrastructure/ProyectoBase.Api.Infrastructure.csproj
@@ -7,26 +7,29 @@
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <CopyDocumentationFileToOutputDirectory>Always</CopyDocumentationFileToOutputDirectory>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AssemblyName>ProyectoBase.Api.Infrastructure</AssemblyName>
+    <RootNamespace>ProyectoBase.Api.Infrastructure</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentValidation.TestHelper" Version="11.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.10" />
+    <PackageReference Include="Polly" Version="7.2.4" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ProyectoBase.Api\ProyectoBase.Api.csproj" />
-    <ProjectReference Include="..\ProyectoBase.Application\ProyectoBase.Application.csproj" />
+    <ProjectReference Include="..\ProyectoBase.Application\ProyectoBase.Api.Application.csproj" />
+    <ProjectReference Include="..\ProyectoBase.Domain\ProyectoBase.Api.Domain.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Persistence\Migrations\**\*.cs" />
   </ItemGroup>
 </Project>

--- a/ProyectoBase.sln
+++ b/ProyectoBase.sln
@@ -2,17 +2,17 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Api", "Backend\ProyectoBase.Api\ProyectoBase.Api.csproj", "{B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Api.Api", "Backend\ProyectoBase.Api\ProyectoBase.Api.Api.csproj", "{B8DBE12D-7833-41CC-8A18-7FDFC610FB8E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Domain", "Backend\ProyectoBase.Domain\ProyectoBase.Domain.csproj", "{C65F0F41-E0CB-4919-8348-DB3AA8A4949F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Api.Domain", "Backend\ProyectoBase.Domain\ProyectoBase.Api.Domain.csproj", "{C65F0F41-E0CB-4919-8348-DB3AA8A4949F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Application", "Backend\ProyectoBase.Application\ProyectoBase.Application.csproj", "{1D73C601-A31A-4F59-A51B-D26E80292F7F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Api.Application", "Backend\ProyectoBase.Application\ProyectoBase.Api.Application.csproj", "{1D73C601-A31A-4F59-A51B-D26E80292F7F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Infrastructure", "Backend\ProyectoBase.Infrastructure\ProyectoBase.Infrastructure.csproj", "{21250535-58FB-4EBE-8A40-202D033FCEAD}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Api.Infrastructure", "Backend\ProyectoBase.Infrastructure\ProyectoBase.Api.Infrastructure.csproj", "{21250535-58FB-4EBE-8A40-202D033FCEAD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Application.Tests", "Backend\ProyectoBase.Application.Tests\ProyectoBase.Application.Tests.csproj", "{DA44A544-1B76-4E7B-94E8-5607068DCE14}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Api.Application.Tests", "Backend\ProyectoBase.Application.Tests\ProyectoBase.Api.Application.Tests.csproj", "{DA44A544-1B76-4E7B-94E8-5607068DCE14}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Domain.Tests", "Backend\ProyectoBase.Domain.Tests\ProyectoBase.Domain.Tests.csproj", "{94E83EA3-E449-4F1B-8BF4-EA3EDF02107A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Api.Domain.Tests", "Backend\ProyectoBase.Domain.Tests\ProyectoBase.Api.Domain.Tests.csproj", "{94E83EA3-E449-4F1B-8BF4-EA3EDF02107A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProyectoBase.Api.IntegrationTests", "Backend\ProyectoBase.Api.IntegrationTests\ProyectoBase.Api.IntegrationTests.csproj", "{4F682FD9-F845-489D-B315-037F000E5173}"
 EndProject


### PR DESCRIPTION
## Summary
- renombré los archivos de proyecto del backend al patrón ProyectoBase.Api.<Capa> y actualicé los metadatos de ensamblado
- actualicé referencias entre proyectos y la solución para apuntar a los nuevos nombres
- ajusté los espacios de nombres del código para alinearlos con los nuevos ensamblados

## Testing
- dotnet build ProyectoBase.sln *(no disponible: el comando dotnet no está instalado en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68def48fd42c832e84d7ada3a879c4fa