### PR TITLE
Update AutoMapper dependencies and registration

### DIFF
--- a/Backend/ProyectoBase.Application/DependencyInjection.cs
+++ b/Backend/ProyectoBase.Application/DependencyInjection.cs
@@ -29,7 +29,7 @@ public static class DependencyInjection
 
         services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
 
-        services.AddAutoMapper(Assembly.GetExecutingAssembly());
+        services.AddAutoMapper(typeof(StartupAssemblyMarker).Assembly);
 
         services.AddScoped<IProductService, ProductService>();
 

--- a/Backend/ProyectoBase.Application/ProyectoBase.Api.Application.csproj
+++ b/Backend/ProyectoBase.Application/ProyectoBase.Api.Application.csproj
@@ -16,7 +16,8 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.9.0" />
     <PackageReference Include="MediatR" Version="12.1.1" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="AutoMapper.Extensions.DependencyInjection" Version="13.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.10" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
       <PrivateAssets>all</PrivateAssets>

--- a/Backend/ProyectoBase.Application/StartupAssemblyMarker.cs
+++ b/Backend/ProyectoBase.Application/StartupAssemblyMarker.cs
@@ -1,0 +1,8 @@
+namespace ProyectoBase.Api.Application;
+
+/// <summary>
+/// Marca la asamblea de inicio para las configuraciones de la capa de aplicación.
+/// </summary>
+internal static class StartupAssemblyMarker
+{
+}


### PR DESCRIPTION
## Summary
- replace the deprecated AutoMapper.Extensions.Microsoft.DependencyInjection package with AutoMapper 13 and the new AutoMapper.Extensions.DependencyInjection package
- register AutoMapper using a startup assembly marker to align with the updated package structure

## Testing
- dotnet restore (fails: dotnet command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68def772e6a4832ea9c0f44b8ef93934