### PR TITLE
Add XML documentation to configuration options

### DIFF
--- a/Backend/ProyectoBase.Api/Options/ConnectionStringsOptions.cs
+++ b/Backend/ProyectoBase.Api/Options/ConnectionStringsOptions.cs
@@ -1,9 +1,22 @@
 namespace ProyectoBase.Api.Api.Options;
 
+/// <summary>
+/// Representa la configuración de cadenas de conexión utilizadas por la aplicación.
+/// </summary>
 public class ConnectionStringsOptions
 {
+    /// <summary>
+    /// Nombre de la sección de configuración que contiene las cadenas de conexión.
+    /// </summary>
     public const string SectionName = "ConnectionStrings";
+
+    /// <summary>
+    /// Nombre de la cadena de conexión predeterminada que debe utilizar la aplicación.
+    /// </summary>
     public const string DefaultConnectionName = "DefaultConnection";
 
+    /// <summary>
+    /// Cadena de conexión utilizada como valor predeterminado para acceder a la base de datos.
+    /// </summary>
     public string DefaultConnection { get; set; } = string.Empty;
 }

--- a/Backend/ProyectoBase.Api/Options/RedisOptions.cs
+++ b/Backend/ProyectoBase.Api/Options/RedisOptions.cs
@@ -1,9 +1,22 @@
 namespace ProyectoBase.Api.Api.Options;
 
+/// <summary>
+/// Representa la configuración necesaria para conectar la aplicación a un servidor de Redis.
+/// </summary>
 public class RedisOptions
 {
+    /// <summary>
+    /// Nombre de la sección de configuración que contiene las opciones de Redis.
+    /// </summary>
     public const string SectionName = "Redis";
 
+    /// <summary>
+    /// Cadena de conexión utilizada para establecer la comunicación con la instancia de Redis.
+    /// </summary>
     public string ConnectionString { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Identificador opcional que se antepone a las claves almacenadas en Redis.
+    /// </summary>
     public string InstanceName { get; set; } = string.Empty;
 }


### PR DESCRIPTION
## Summary
- add XML documentation to the Redis configuration options
- add XML documentation to the connection strings configuration options

## Testing
- not run (environment lacks dotnet SDK)

------
https://chatgpt.com/codex/tasks/task_e_68df1010f7e8832e89a28f673c1e6fa7