### PR TITLE
Add infrastructure project reference to API project

### DIFF
--- a/Backend/ProyectoBase.Api/ProyectoBase.Api.Api.csproj
+++ b/Backend/ProyectoBase.Api/ProyectoBase.Api.Api.csproj
@@ -29,6 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ProyectoBase.Application\ProyectoBase.Api.Application.csproj" />
+    <ProjectReference Include="..\ProyectoBase.Infrastructure\ProyectoBase.Api.Infrastructure.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Update="nlog.config">

--- a/Backend/ProyectoBase.Infrastructure/ProyectoBase.Api.Infrastructure.csproj
+++ b/Backend/ProyectoBase.Infrastructure/ProyectoBase.Api.Infrastructure.csproj
@@ -29,7 +29,4 @@
     <ProjectReference Include="..\ProyectoBase.Application\ProyectoBase.Api.Application.csproj" />
     <ProjectReference Include="..\ProyectoBase.Domain\ProyectoBase.Api.Domain.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Persistence\Migrations\**\*.cs" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add the infrastructure project as a reference from the API project so it can resolve its services
- remove the explicit migration compile include to rely on the SDK default globbing

## Testing
- ❌ `dotnet build ProyectoBase.sln` *(fails: `dotnet` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df16af82d0832eaefb0a62c58ed4ac