### PR TITLE
Ensure product not found integration test validates standardized error payload

### DIFF
--- a/Backend/ProyectoBase.Api.IntegrationTests/Controllers/V1/ProductsControllerTests.cs
+++ b/Backend/ProyectoBase.Api.IntegrationTests/Controllers/V1/ProductsControllerTests.cs
@@ -67,6 +67,14 @@ public class ProductsControllerTests : IClassFixture<CustomWebApplicationFactory
         var response = await _client.GetAsync($"/api/v1/Products/{Guid.NewGuid()}").ConfigureAwait(false);
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var error = await ReadStandardErrorAsync(response).ConfigureAwait(false);
+
+        error.Should().NotBeNull();
+        error!.Status.Should().Be((int)HttpStatusCode.NotFound);
+        error.Error.Message.Should().Be("Recurso no encontrado");
+        error.Details.ValueKind.Should().Be(JsonValueKind.String);
+        error.Details.GetString().Should().Contain("El producto solicitado no fue encontrado.");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- extend the product not found integration test to deserialize the standardized error payload returned by the exception handling middleware
- assert the status, message, and details of the error contract to align with the middleware format

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dfbdad6784832e83cf9541467f8193