### PR TITLE
Add boundary validation tests for product DTO validators

### DIFF
--- a/Backend/ProyectoBase.Application.Tests/Validators/CreateProductDtoValidatorTests.cs
+++ b/Backend/ProyectoBase.Application.Tests/Validators/CreateProductDtoValidatorTests.cs
@@ -43,6 +43,92 @@ public class CreateProductDtoValidatorTests
     }
 
     [Fact]
+    public void Should_fail_when_name_is_shorter_than_minimum_allowed()
+    {
+        var dto = new ProductCreateDto
+        {
+            Name = "A",
+            Price = 10,
+            Stock = 1
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(product => product.Name)
+            .WithErrorMessage("El nombre debe tener entre 2 y 100 caracteres.")
+            .WithErrorCode("LengthValidator");
+    }
+
+    [Fact]
+    public void Should_fail_when_name_is_longer_than_maximum_allowed()
+    {
+        var dto = new ProductCreateDto
+        {
+            Name = new string('A', 101),
+            Price = 10,
+            Stock = 1
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(product => product.Name)
+            .WithErrorMessage("El nombre debe tener entre 2 y 100 caracteres.")
+            .WithErrorCode("LengthValidator");
+    }
+
+    [Fact]
+    public void Should_fail_when_description_exceeds_maximum_length()
+    {
+        var dto = new ProductCreateDto
+        {
+            Name = "Valid name",
+            Description = new string('D', 501),
+            Price = 10,
+            Stock = 1
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(product => product.Description)
+            .WithErrorMessage("La descripción no puede superar los 500 caracteres.")
+            .WithErrorCode("MaximumLengthValidator");
+    }
+
+    [Fact]
+    public void Should_fail_when_price_exceeds_maximum_allowed()
+    {
+        var dto = new ProductCreateDto
+        {
+            Name = "Valid name",
+            Price = 1_000_000m,
+            Stock = 1
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(product => product.Price)
+            .WithErrorMessage("El precio no puede superar 999.999,99.")
+            .WithErrorCode("LessThanOrEqualValidator");
+    }
+
+    [Fact]
+    public void Should_fail_when_stock_is_negative()
+    {
+        var dto = new ProductCreateDto
+        {
+            Name = "Valid name",
+            Price = 10,
+            Stock = -1
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(product => product.Stock)
+            .WithErrorMessage("El inventario debe ser un número mayor o igual que cero.")
+            .WithErrorCode("GreaterThanOrEqualValidator");
+    }
+
+    [Fact]
     public void Should_pass_when_dto_is_valid()
     {
         var dto = new ProductCreateDto

--- a/Backend/ProyectoBase.Application.Tests/Validators/UpdateProductDtoValidatorTests.cs
+++ b/Backend/ProyectoBase.Application.Tests/Validators/UpdateProductDtoValidatorTests.cs
@@ -43,4 +43,95 @@ public class UpdateProductDtoValidatorTests
 
         result.ShouldHaveValidationErrorFor(product => product.Name);
     }
+
+    [Fact]
+    public void Should_fail_when_name_is_shorter_than_minimum_allowed()
+    {
+        var dto = new ProductUpdateDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "A",
+            Price = 10,
+            Stock = 1
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(product => product.Name)
+            .WithErrorMessage("El nombre debe tener entre 2 y 100 caracteres.")
+            .WithErrorCode("LengthValidator");
+    }
+
+    [Fact]
+    public void Should_fail_when_name_is_longer_than_maximum_allowed()
+    {
+        var dto = new ProductUpdateDto
+        {
+            Id = Guid.NewGuid(),
+            Name = new string('A', 101),
+            Price = 10,
+            Stock = 1
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(product => product.Name)
+            .WithErrorMessage("El nombre debe tener entre 2 y 100 caracteres.")
+            .WithErrorCode("LengthValidator");
+    }
+
+    [Fact]
+    public void Should_fail_when_description_exceeds_maximum_length()
+    {
+        var dto = new ProductUpdateDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "Valid name",
+            Description = new string('D', 501),
+            Price = 10,
+            Stock = 1
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(product => product.Description)
+            .WithErrorMessage("La descripción no puede superar los 500 caracteres.")
+            .WithErrorCode("MaximumLengthValidator");
+    }
+
+    [Fact]
+    public void Should_fail_when_price_exceeds_maximum_allowed()
+    {
+        var dto = new ProductUpdateDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "Valid name",
+            Price = 1_000_000m,
+            Stock = 1
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(product => product.Price)
+            .WithErrorMessage("El precio no puede superar 999.999,99.")
+            .WithErrorCode("LessThanOrEqualValidator");
+    }
+
+    [Fact]
+    public void Should_fail_when_stock_is_negative()
+    {
+        var dto = new ProductUpdateDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "Valid name",
+            Price = 10,
+            Stock = -1
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(product => product.Stock)
+            .WithErrorMessage("El inventario debe ser un número mayor o igual que cero.")
+            .WithErrorCode("GreaterThanOrEqualValidator");
+    }
 }


### PR DESCRIPTION
## Summary
- add boundary validation tests covering name, description, price, and stock limits for product creation
- replicate the extended validation boundary coverage for product updates to demonstrate inherited rules

## Testing
- `dotnet test` *(fails: `dotnet`: command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfbe61a380832ea5249361e109de31