### PR TITLE
Adjust error detail assertions for array-based payloads

### DIFF
--- a/Backend/ProyectoBase.Api.IntegrationTests/Controllers/V1/ProductsControllerTests.cs
+++ b/Backend/ProyectoBase.Api.IntegrationTests/Controllers/V1/ProductsControllerTests.cs
@@ -7,6 +7,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
+using ProyectoBase.Api.Domain;
 using ProyectoBase.Api.IntegrationTests.Infrastructure;
 using ProyectoBase.Api.Application.DTOs;
 using Xunit;
@@ -73,8 +74,17 @@ public class ProductsControllerTests : IClassFixture<CustomWebApplicationFactory
         error.Should().NotBeNull();
         error!.Status.Should().Be((int)HttpStatusCode.NotFound);
         error.Error.Message.Should().Be("Recurso no encontrado");
-        error.Details.ValueKind.Should().Be(JsonValueKind.String);
-        error.Details.GetString().Should().Contain("El producto solicitado no fue encontrado.");
+        error.Details.ValueKind.Should().Be(JsonValueKind.Array);
+
+        var details = error.Details.EnumerateArray().ToArray();
+        details.Should().HaveCount(1);
+
+        var detail = details[0];
+        detail.ValueKind.Should().Be(JsonValueKind.Object);
+        detail.TryGetProperty("code", out var code).Should().BeTrue();
+        detail.TryGetProperty("message", out var message).Should().BeTrue();
+        code.GetString().Should().Be(DomainErrorCodes.NotFound);
+        message.GetString().Should().Be("El producto solicitado no fue encontrado.");
     }
 
     [Fact]
@@ -279,8 +289,17 @@ public class ProductsControllerTests : IClassFixture<CustomWebApplicationFactory
         error.Should().NotBeNull();
         error!.Status.Should().Be((int)HttpStatusCode.NotFound);
         error.Error.Message.Should().Be("Recurso no encontrado");
-        error.Details.ValueKind.Should().Be(JsonValueKind.String);
-        error.Details.GetString().Should().Contain("El producto solicitado no fue encontrado.");
+        error.Details.ValueKind.Should().Be(JsonValueKind.Array);
+
+        var details = error.Details.EnumerateArray().ToArray();
+        details.Should().HaveCount(1);
+
+        var detail = details[0];
+        detail.ValueKind.Should().Be(JsonValueKind.Object);
+        detail.TryGetProperty("code", out var code).Should().BeTrue();
+        detail.TryGetProperty("message", out var message).Should().BeTrue();
+        code.GetString().Should().Be(DomainErrorCodes.NotFound);
+        message.GetString().Should().Be("El producto solicitado no fue encontrado.");
     }
 
     private static async Task<ProductResponseDto> CreateProductAsync(HttpClient client, ProductCreateDto request)

--- a/Backend/ProyectoBase.Application.Tests/Middlewares/ExceptionHandlingMiddlewareTests.cs
+++ b/Backend/ProyectoBase.Application.Tests/Middlewares/ExceptionHandlingMiddlewareTests.cs
@@ -81,7 +81,21 @@ public class ExceptionHandlingMiddlewareTests
         var error = response.GetProperty("error");
         Assert.Equal(DomainErrorCodes.NotFound, error.GetProperty("code").GetString());
         Assert.Equal("Recurso no encontrado", error.GetProperty("message").GetString());
-        Assert.Equal(DomainErrors.Product.NotFound(Guid.Empty).Message, response.GetProperty("details").GetString());
+
+        var details = response.GetProperty("details");
+        Assert.Equal(JsonValueKind.Array, details.ValueKind);
+
+        var detailItems = details
+            .EnumerateArray()
+            .Select(element => new ErrorDetail(
+                element.GetProperty("code").GetString(),
+                element.GetProperty("message").GetString()))
+            .ToArray();
+
+        Assert.Single(detailItems);
+        var expectedError = DomainErrors.Product.NotFound(Guid.Empty);
+        Assert.Equal(expectedError.Code, detailItems[0].Code);
+        Assert.Equal(expectedError.Message, detailItems[0].Message);
     }
 
     [Fact]
@@ -95,7 +109,20 @@ public class ExceptionHandlingMiddlewareTests
         var error = response.GetProperty("error");
         Assert.Equal(ApiErrorCodes.Unexpected, error.GetProperty("code").GetString());
         Assert.Equal("Error interno del servidor", error.GetProperty("message").GetString());
-        Assert.Equal("Ocurrió un error inesperado.", response.GetProperty("details").GetString());
+
+        var details = response.GetProperty("details");
+        Assert.Equal(JsonValueKind.Array, details.ValueKind);
+
+        var detailItems = details
+            .EnumerateArray()
+            .Select(element => new ErrorDetail(
+                element.GetProperty("code").GetString(),
+                element.GetProperty("message").GetString()))
+            .ToArray();
+
+        Assert.Single(detailItems);
+        Assert.Equal(ApiErrorCodes.Unexpected, detailItems[0].Code);
+        Assert.Equal("Ocurrió un error inesperado.", detailItems[0].Message);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- update exception handling middleware unit tests to validate array-shaped error details for 404 and 500 responses
- adjust product controller integration tests to inspect the array of detail objects returned in not found scenarios

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfc63382a4832ea14eae2b91460e7d