### PR TITLE
Actualiza paquetes de health checks

### DIFF
--- a/Backend/ProyectoBase.Api/ProyectoBase.Api.Api.csproj
+++ b/Backend/ProyectoBase.Api/ProyectoBase.Api.Api.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Redis" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.SqlServer" Version="8.0.8" />
+    <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="8.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
- replace the Redis and SQL Server health check packages with the AspNetCore.HealthChecks equivalents targeting .NET 8

## Testing
- dotnet restore *(fails: `dotnet` command is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd12f8f9c832eaf1d8c52cd1108f7