### PR TITLE
Add Microsoft.Extensions.Logging.Abstractions package references

### DIFF
--- a/Backend/ProyectoBase.Application/ProyectoBase.Api.Application.csproj
+++ b/Backend/ProyectoBase.Application/ProyectoBase.Api.Application.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Backend/ProyectoBase.Infrastructure/ProyectoBase.Api.Infrastructure.csproj
+++ b/Backend/ProyectoBase.Infrastructure/ProyectoBase.Api.Infrastructure.csproj
@@ -18,6 +18,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="Polly" Version="7.2.4" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">


### PR DESCRIPTION
## Summary
- add the Microsoft.Extensions.Logging.Abstractions package to the application and infrastructure projects so Microsoft.Extensions.Logging dependencies resolve consistently

## Testing
- not run (dotnet CLI unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfd3bfe404832eb977495ed2566f51