### PR TITLE
Actualiza dependencias de FluentValidation en pruebas

### DIFF
--- a/Backend/ProyectoBase.Application.Tests/ProyectoBase.Api.Application.Tests.csproj
+++ b/Backend/ProyectoBase.Application.Tests/ProyectoBase.Api.Application.Tests.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>ProyectoBase.Api.Application.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentValidation.TestHelper" Version="11.9.0" />
+    <PackageReference Include="FluentValidation" Version="11.9.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.0" />


### PR DESCRIPTION
## Summary
- Replace FluentValidation.TestHelper package with a direct FluentValidation reference in the test project

## Testing
- dotnet restore *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd443c7d8832eb4d77d4f31cd0cea