### PR TITLE
Document logging abstractions package references

### DIFF
--- a/Backend/ProyectoBase.Application/ProyectoBase.Api.Application.csproj
+++ b/Backend/ProyectoBase.Application/ProyectoBase.Api.Application.csproj
@@ -19,7 +19,9 @@
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1">
+      <!-- Required to resolve ILogger dependencies in the application layer. -->
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Backend/ProyectoBase.Infrastructure/ProyectoBase.Api.Infrastructure.csproj
+++ b/Backend/ProyectoBase.Infrastructure/ProyectoBase.Api.Infrastructure.csproj
@@ -18,7 +18,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1">
+      <!-- Required to resolve ILogger dependencies in the infrastructure layer. -->
+    </PackageReference>
     <PackageReference Include="Polly" Version="7.2.4" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">


### PR DESCRIPTION
## Summary
- document the Microsoft.Extensions.Logging.Abstractions dependency in the application project to clarify ILogger usage
- document the Microsoft.Extensions.Logging.Abstractions dependency in the infrastructure project for consistency

## Testing
- `dotnet restore ProyectoBase.sln` *(fails: dotnet CLI is not installed in the execution environment)*
- `dotnet build ProyectoBase.sln` *(fails: dotnet CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd6313984832eabc4321eba0ff011