### PR TITLE
Fix FluentValidation DI registration compilation error

### DIFF
--- a/Backend/ProyectoBase.Application/DependencyInjection.cs
+++ b/Backend/ProyectoBase.Application/DependencyInjection.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using FluentValidation;
+using FluentValidation.DependencyInjectionExtensions;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 


### PR DESCRIPTION
## Summary
- import the FluentValidation dependency injection extensions namespace so AddValidatorsFromAssembly is available during application registration

## Testing
- dotnet build *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdcbd54fc832ea10bb448579a76c2