### PR TITLE
Add FluentValidation DI extensions package

### DIFF
--- a/Backend/ProyectoBase.Application/ProyectoBase.Api.Application.csproj
+++ b/Backend/ProyectoBase.Application/ProyectoBase.Api.Application.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.9.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
     <PackageReference Include="MediatR" Version="12.1.1" />
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />


### PR DESCRIPTION
## Summary
- add the FluentValidation dependency injection extensions package reference so AddValidatorsFromAssembly can be resolved

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dff11d9468832e83f7a05eb68b2ff0