### PR TITLE
Register validators using assembly marker

### DIFF
--- a/Backend/ProyectoBase.Application/DependencyInjection.cs
+++ b/Backend/ProyectoBase.Application/DependencyInjection.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Reflection;
 using FluentValidation;
-using FluentValidation.DependencyInjectionExtensions;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -26,7 +25,7 @@ public static class DependencyInjection
             configuration.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly());
         });
 
-        services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
+        services.AddValidatorsFromAssemblyContaining<StartupAssemblyMarker>();
 
         services.AddAutoMapper(typeof(StartupAssemblyMarker).Assembly);
 

--- a/Backend/ProyectoBase.Application/ProyectoBase.Api.Application.csproj
+++ b/Backend/ProyectoBase.Application/ProyectoBase.Api.Application.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.9.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
     <PackageReference Include="MediatR" Version="12.1.1" />
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />


### PR DESCRIPTION
## Summary
- switch validator registration to AddValidatorsFromAssemblyContaining using the StartupAssemblyMarker
- remove the unnecessary FluentValidation.DependencyInjectionExtensions using directive that Visual Studio flagged

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dff11d9468832e83f7a05eb68b2ff0