### PR TITLE
Fix Polly circuit breaker configuration build error

### DIFF
--- a/Backend/ProyectoBase.Infrastructure/DependencyInjection.cs
+++ b/Backend/ProyectoBase.Infrastructure/DependencyInjection.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Polly;
 using Polly.Registry;
+using Polly.CircuitBreaker;
 using ProyectoBase.Api.Application.Abstractions;
 using ProyectoBase.Api.Infrastructure.Authentication;
 using ProyectoBase.Api.Infrastructure.Persistence;


### PR DESCRIPTION
## Summary
- add the missing Polly.CircuitBreaker namespace import so the circuit breaker policy extension compiles

## Testing
- dotnet build *(fails: dotnet CLI not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e504d246cc832e832b0baf98fc6ee4