### PR TITLE
Fix Polly circuit breaker configuration build error

### DIFF
--- a/Backend/ProyectoBase.Infrastructure/DependencyInjection.cs
+++ b/Backend/ProyectoBase.Infrastructure/DependencyInjection.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Polly;
 using Polly.Registry;
+using Polly.CircuitBreaker;
 using ProyectoBase.Api.Application.Abstractions;
 using ProyectoBase.Api.Infrastructure.Authentication;
 using ProyectoBase.Api.Infrastructure.Persistence;
@@ -77,11 +78,11 @@ public static class DependencyInjection
             var circuitBreakerPolicy = Policy.Handle<Exception>().CircuitBreakerAsync(
                 handledEventsAllowedBeforeBreaking: 5,
                 durationOfBreak: TimeSpan.FromSeconds(30),
-                onBreak: (exception, breakDelay) =>
+                onBreak: (exception, breakDelay, _) =>
                 {
                     logger.LogError(exception, "Circuito abierto durante {Delay} segundos debido a fallas reiteradas.", breakDelay.TotalSeconds);
                 },
-                onReset: () => logger.LogInformation("Circuito cerrado: las operaciones se estabilizaron."),
+                onReset: _ => logger.LogInformation("Circuito cerrado: las operaciones se estabilizaron."),
                 onHalfOpen: () => logger.LogInformation("Circuito medio abierto: la siguiente llamada es de prueba."));
 
             registry.Add(RetryPolicyName, retryPolicy);


### PR DESCRIPTION
## Summary
- add the missing Polly.CircuitBreaker namespace import so the circuit breaker policy extension compiles
- update the circuit breaker callbacks to match the async overload signature expected by Polly

## Testing
- dotnet build *(fails: dotnet CLI not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e504d246cc832e832b0baf98fc6ee4