### PR TITLE
Add Flask-based food image analyzer web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,3 +251,31 @@ Autenticación con JWT.
 CI/CD en GitHub Actions o Azure DevOps.
 Pruebas unitarias y E2E.
 ```
+
+## 🧠 Chef Visual (Python + IA ligera)
+
+Se incluye una miniaplicación en `python_app/` construida con **Flask** que permite:
+
+- Subir imágenes de comida (validación de tipo y tamaño hasta 5 MB).
+- Analizar colores predominantes de la imagen con Pillow para inferir la categoría del plato.
+- Generar sugerencias de recetas y porciones basadas en reglas heurísticas inspiradas en IA.
+
+### Ejecución
+
+```bash
+cd python_app
+python -m venv .venv
+source .venv/bin/activate  # En Windows usa .venv\Scripts\activate
+pip install -r requirements.txt
+python app.py
+```
+
+La aplicación quedará disponible en `http://localhost:5000`.
+
+### Uso
+
+1. Abre la página principal.
+2. Arrastra o selecciona una imagen de comida en formato JPG, PNG o GIF.
+3. Presiona **Analizar imagen** para obtener la categoría estimada, una receta sugerida y las porciones recomendadas.
+
+> ℹ️ El análisis utiliza heurísticas ligeras en función del color dominante y brillo de la imagen para ofrecer sugerencias inmediatas sin depender de servicios externos.

--- a/python_app/.gitignore
+++ b/python_app/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.venv/
+instance/
+*.pyc

--- a/python_app/app.py
+++ b/python_app/app.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import base64
+import io
+import os
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+from flask import Flask, jsonify, render_template, request
+from PIL import Image, ImageStat
+from werkzeug.utils import secure_filename
+
+
+ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif"}
+MAX_UPLOAD_SIZE = 5 * 1024 * 1024  # 5 MB
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+    app.config["MAX_CONTENT_LENGTH"] = MAX_UPLOAD_SIZE
+
+    @app.route("/")
+    def index() -> str:
+        return render_template("index.html")
+
+    @app.post("/analyze")
+    def analyze() -> Tuple[str, int]:
+        if "image" not in request.files:
+            return jsonify({"error": "No se ha enviado ninguna imagen."}), 400
+
+        file_storage = request.files["image"]
+        filename = secure_filename(file_storage.filename)
+        if filename == "":
+            return jsonify({"error": "Debes seleccionar un archivo de imagen."}), 400
+
+        extension = os.path.splitext(filename)[1].lower()
+        if extension not in ALLOWED_EXTENSIONS:
+            return (
+                jsonify(
+                    {
+                        "error": "Formato no soportado. Usa JPG, PNG o GIF.",
+                    }
+                ),
+                400,
+            )
+
+        try:
+            image_bytes = file_storage.read()
+            file_storage.stream.seek(0)
+            image = Image.open(io.BytesIO(image_bytes))
+            image.verify()
+            file_storage.stream.seek(0)
+            image = Image.open(file_storage.stream).convert("RGB")
+        except Exception:  # pragma: no cover - Pillow raises various subclasses
+            return jsonify({"error": "No se pudo procesar la imagen proporcionada."}), 400
+
+        analysis = analyze_image(image)
+
+        buffered = io.BytesIO()
+        image.save(buffered, format="JPEG", quality=80)
+        encoded_image = base64.b64encode(buffered.getvalue()).decode("ascii")
+
+        response = {
+            "category": analysis.category,
+            "confidence": analysis.confidence,
+            "recipe": analysis.recipe,
+            "portions": analysis.portions,
+            "image": f"data:image/jpeg;base64,{encoded_image}",
+        }
+        return jsonify(response)
+
+    return app
+
+
+@dataclass
+class RecipeSuggestion:
+    category: str
+    confidence: int
+    recipe: Dict[str, object]
+    portions: Dict[str, object]
+
+
+def analyze_image(image: Image.Image) -> RecipeSuggestion:
+    """Generate a lightweight AI-inspired analysis for the uploaded food image."""
+    resized = image.resize((128, 128))
+    stat = ImageStat.Stat(resized)
+    r, g, b = stat.mean
+    brightness = sum(stat.mean) / 3
+
+    dominant_color = max((r, "rojo"), (g, "verde"), (b, "azul"), key=lambda x: x[0])[1]
+
+    if dominant_color == "verde" and brightness > 90:
+        category = "Ensalada fresca"
+        recipe = {
+            "titulo": "Ensalada mediterránea",
+            "ingredientes": [
+                "2 tazas de hojas verdes mixtas",
+                "1/2 taza de tomates cherry",
+                "1/4 taza de pepino en cubos",
+                "Queso feta desmenuzado",
+                "Aceite de oliva, limón y orégano",
+            ],
+            "pasos": [
+                "Mezcla las hojas verdes con el pepino y los tomates.",
+                "Añade el queso feta y aliña con aceite de oliva, limón y orégano.",
+            ],
+        }
+        portions = {
+            "porcion_recomendada": "1 bol individual",
+            "calorias_estimadas": 320,
+        }
+        confidence = 78
+    elif dominant_color == "rojo" and brightness > 60:
+        category = "Plato a base de tomate"
+        recipe = {
+            "titulo": "Pasta pomodoro rápida",
+            "ingredientes": [
+                "120 g de pasta larga",
+                "1 taza de salsa de tomate natural",
+                "1 diente de ajo",
+                "Hojas de albahaca fresca",
+                "Aceite de oliva y sal",
+            ],
+            "pasos": [
+                "Cocina la pasta al dente.",
+                "Saltea ajo en aceite, añade la salsa de tomate y cocina 5 minutos.",
+                "Mezcla con la pasta y decora con albahaca.",
+            ],
+        }
+        portions = {
+            "porcion_recomendada": "1 plato (aprox. 2 tazas)",
+            "calorias_estimadas": 540,
+        }
+        confidence = 74
+    elif brightness < 70:
+        category = "Guiso abundante"
+        recipe = {
+            "titulo": "Estofado rústico",
+            "ingredientes": [
+                "150 g de carne o proteína vegetal",
+                "1 papa grande",
+                "1 zanahoria",
+                "1 taza de caldo",
+                "Especias al gusto",
+            ],
+            "pasos": [
+                "Dora la proteína en una olla.",
+                "Agrega vegetales en cubos y el caldo.",
+                "Cocina tapado 25 minutos hasta que espese.",
+            ],
+        }
+        portions = {
+            "porcion_recomendada": "1 plato hondo",
+            "calorias_estimadas": 610,
+        }
+        confidence = 70
+    else:
+        category = "Postre o desayuno dulce"
+        recipe = {
+            "titulo": "Parfait de frutas y yogurt",
+            "ingredientes": [
+                "1 taza de yogurt natural",
+                "1 taza de frutas frescas variadas",
+                "1/4 taza de granola",
+                "Miel al gusto",
+            ],
+            "pasos": [
+                "En un vaso coloca capas de yogurt, frutas y granola.",
+                "Repite hasta llenar y termina con un hilo de miel.",
+            ],
+        }
+        portions = {
+            "porcion_recomendada": "1 vaso (250 ml)",
+            "calorias_estimadas": 380,
+        }
+        confidence = 65
+
+    return RecipeSuggestion(
+        category=category,
+        confidence=confidence,
+        recipe=recipe,
+        portions=portions,
+    )
+
+
+if __name__ == "__main__":
+    app = create_app()
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/python_app/requirements.txt
+++ b/python_app/requirements.txt
@@ -1,0 +1,3 @@
+Flask==3.0.2
+Werkzeug==3.0.1
+Pillow==10.2.0

--- a/python_app/static/styles.css
+++ b/python_app/static/styles.css
@@ -1,0 +1,191 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top, #ffedd5, #fde68a 45%, #f5d0fe 100%);
+  min-height: 100vh;
+}
+
+body {
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 2rem 1rem;
+}
+
+.container {
+  background-color: rgba(255, 255, 255, 0.9);
+  border-radius: 24px;
+  max-width: 960px;
+  width: 100%;
+  padding: 2.5rem 3rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.2);
+}
+
+header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+h1 {
+  margin: 0;
+  font-size: 2.5rem;
+  color: #1f2937;
+}
+
+header p {
+  color: #4b5563;
+}
+
+.upload {
+  margin-bottom: 2.5rem;
+}
+
+.drop-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 2px dashed #a855f7;
+  padding: 2rem;
+  border-radius: 16px;
+  background-color: rgba(250, 245, 255, 0.8);
+  color: #6b21a8;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.drop-area:hover,
+.drop-area:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 25px rgba(168, 85, 247, 0.2);
+}
+
+.drop-area .icon {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.drop-area .cta {
+  font-weight: 600;
+}
+
+.drop-area .hint {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+}
+
+button[type="submit"] {
+  margin-top: 1.5rem;
+  padding: 0.9rem 1.5rem;
+  border-radius: 12px;
+  border: none;
+  background: linear-gradient(90deg, #a855f7, #ec4899);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button[type="submit"]:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 25px rgba(236, 72, 153, 0.3);
+}
+
+.error {
+  color: #b91c1c;
+  margin-top: 1rem;
+  text-align: center;
+}
+
+.results {
+  display: flex;
+  gap: 2rem;
+  align-items: flex-start;
+}
+
+.results.hidden {
+  display: none;
+}
+
+.preview {
+  flex: 1;
+}
+
+.preview img {
+  max-width: 100%;
+  border-radius: 16px;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.2);
+}
+
+.details {
+  flex: 1.2;
+  background-color: rgba(255, 255, 255, 0.9);
+  padding: 1.5rem;
+  border-radius: 16px;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.12);
+}
+
+.details h2 {
+  margin-top: 0;
+  color: #9333ea;
+}
+
+.details article + article {
+  margin-top: 1.5rem;
+}
+
+.details ul,
+.details ol {
+  padding-left: 1.2rem;
+  color: #1f2937;
+}
+
+.details li {
+  margin-bottom: 0.5rem;
+}
+
+.portions ul {
+  list-style: disc;
+}
+
+@media (max-width: 900px) {
+  .results {
+    flex-direction: column;
+  }
+
+  .container {
+    padding: 2rem;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    background: radial-gradient(circle at top, #1f2937, #111827 60%, #000000 100%);
+  }
+
+  .container {
+    background-color: rgba(17, 24, 39, 0.85);
+    box-shadow: 0 20px 45px rgba(0, 0, 0, 0.5);
+  }
+
+  h1,
+  header p,
+  .drop-area,
+  .details,
+  .details ul,
+  .details ol,
+  .details li {
+    color: #f9fafb;
+  }
+
+  .drop-area {
+    border-color: #6366f1;
+    background-color: rgba(79, 70, 229, 0.2);
+  }
+
+  button[type="submit"] {
+    box-shadow: none;
+  }
+}

--- a/python_app/templates/index.html
+++ b/python_app/templates/index.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chef Visual</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
+  </head>
+  <body>
+    <main class="container">
+      <header>
+        <h1>Chef Visual</h1>
+        <p>
+          Sube una foto de tu comida y obten una sugerencia de receta y porciones
+          generada por IA ligera.
+        </p>
+      </header>
+
+      <section class="upload" id="upload-area">
+        <form id="upload-form">
+          <label for="image-input" class="drop-area">
+            <input type="file" id="image-input" name="image" accept="image/*" hidden />
+            <span class="icon">📷</span>
+            <span class="cta">Haz clic o arrastra una imagen aquí</span>
+            <span class="hint">Formatos permitidos: JPG, PNG, GIF (máx. 5 MB)</span>
+          </label>
+          <button type="submit">Analizar imagen</button>
+        </form>
+        <p class="error" id="error-message" role="alert"></p>
+      </section>
+
+      <section class="results hidden" id="results">
+        <div class="preview">
+          <img id="preview-image" alt="Vista previa de la imagen cargada" />
+        </div>
+        <div class="details">
+          <h2 id="category"></h2>
+          <p class="confidence"></p>
+
+          <article>
+            <h3 id="recipe-title"></h3>
+            <h4>Ingredientes</h4>
+            <ul id="ingredients"></ul>
+            <h4>Pasos</h4>
+            <ol id="steps"></ol>
+          </article>
+
+          <article class="portions">
+            <h3>Porciones sugeridas</h3>
+            <ul id="portions"></ul>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <template id="list-item">
+      <li></li>
+    </template>
+
+    <script>
+      const form = document.getElementById("upload-form");
+      const fileInput = document.getElementById("image-input");
+      const errorMessage = document.getElementById("error-message");
+      const results = document.getElementById("results");
+      const previewImage = document.getElementById("preview-image");
+      const category = document.getElementById("category");
+      const confidence = document.querySelector(".confidence");
+      const recipeTitle = document.getElementById("recipe-title");
+      const ingredients = document.getElementById("ingredients");
+      const steps = document.getElementById("steps");
+      const portions = document.getElementById("portions");
+      const listTemplate = document.getElementById("list-item");
+
+      const MAX_SIZE = 5 * 1024 * 1024; // 5 MB
+      const VALID_TYPES = ["image/jpeg", "image/png", "image/gif"];
+
+      form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        errorMessage.textContent = "";
+
+        if (!fileInput.files || fileInput.files.length === 0) {
+          errorMessage.textContent = "Selecciona una imagen antes de continuar.";
+          return;
+        }
+
+        const file = fileInput.files[0];
+        if (!VALID_TYPES.includes(file.type)) {
+          errorMessage.textContent = "El archivo debe ser JPG, PNG o GIF.";
+          return;
+        }
+
+        if (file.size > MAX_SIZE) {
+          errorMessage.textContent = "El archivo supera el tamaño máximo de 5 MB.";
+          return;
+        }
+
+        const formData = new FormData();
+        formData.append("image", file);
+
+        try {
+          const response = await fetch("/analyze", {
+            method: "POST",
+            body: formData,
+          });
+
+          const data = await response.json();
+          if (!response.ok) {
+            throw new Error(data.error || "No se pudo analizar la imagen.");
+          }
+
+          renderResults(data);
+        } catch (error) {
+          errorMessage.textContent = error.message;
+        }
+      });
+
+      function renderResults(data) {
+        previewImage.src = data.image;
+        category.textContent = data.category;
+        confidence.textContent = `Confianza estimada: ${data.confidence}%`;
+        recipeTitle.textContent = data.recipe.titulo;
+
+        populateList(ingredients, data.recipe.ingredientes);
+        populateList(steps, data.recipe.pasos, true);
+
+        const portionsData = [
+          `Porción recomendada: ${data.portions.porcion_recomendada}`,
+          `Calorías estimadas: ${data.portions.calorias_estimadas} kcal`,
+        ];
+        populateList(portions, portionsData);
+
+        results.classList.remove("hidden");
+        results.scrollIntoView({ behavior: "smooth" });
+      }
+
+      function populateList(container, items, ordered = false) {
+        container.innerHTML = "";
+        items.forEach((item, index) => {
+          const element = listTemplate.content.firstElementChild.cloneNode(true);
+          element.textContent = ordered ? `${index + 1}. ${item}` : item;
+          container.appendChild(element);
+        });
+      }
+
+      fileInput.addEventListener("change", () => {
+        if (!fileInput.files || fileInput.files.length === 0) {
+          return;
+        }
+
+        const file = fileInput.files[0];
+        if (!VALID_TYPES.includes(file.type) || file.size > MAX_SIZE) {
+          previewImage.removeAttribute("src");
+          return;
+        }
+
+        const reader = new FileReader();
+        reader.onload = (event) => {
+          previewImage.src = event.target.result;
+          results.classList.remove("hidden");
+        };
+        reader.readAsDataURL(file);
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a lightweight Flask service that validates food image uploads and generates recipe plus portion suggestions
- create the accompanying template, styling, and static behavior for the Chef Visual interface
- document how to set up and run the new python_app utility from the repository README

## Testing
- python -m compileall python_app

------
https://chatgpt.com/codex/tasks/task_e_68e840a8b700832eb896c5242b680bbb